### PR TITLE
add variable size cols

### DIFF
--- a/app/main.f90
+++ b/app/main.f90
@@ -33,6 +33,14 @@ program main
     call df%append(["test1","test2","test3","test4"])
     call df%write()
 
+    print*, "num elems in real col: ", df%nrows(2)
+    print*, "num elems in char col: ", df%nrows(3)
+    print*, "most num elems in a col: ", df%nrows()
+
+    call df%destroy()
+
+    print*, " " ! newline
+
 
 
     ! Make truth table for AND gate
@@ -56,5 +64,7 @@ program main
     print*, "logical:   ", LOGICAL_NUM
     print*, "character: ", CHARACTER_NUM
     print*, "complex:   ", COMPLEX_NUM
+
+    call df%destroy()
 
 end program main

--- a/app/main.f90
+++ b/app/main.f90
@@ -26,6 +26,14 @@ program main
 
     print*, " " ! newline
 
+    ! Variable length cols
+    call df%new(enforce_length=.false.)
+    call df%append([1,2,3,4,5,6,7,8,9,10])
+    call df%append([1.0_rk, 2.0_rk, 3.0_rk])
+    call df%append(["test1","test2","test3","test4"])
+    call df%write()
+
+
 
     ! Make truth table for AND gate
     call df%new()

--- a/src/df_fortranDF.f90
+++ b/src/df_fortranDF.f90
@@ -632,7 +632,10 @@ contains
 
         if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_len
 
-        if (this%n < 1 .and. present(header)) this%with_headers = .true.
+        if (this%n < 1) then
+            this%with_headers = .false.
+            if (present(header)) this%with_headers = .true.
+        end if
 
         if (this%rrows_max < 0) then
             call this%add_col_real(col)
@@ -674,7 +677,10 @@ contains
 
         if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_len
 
-        if (this%n < 1 .and. present(header)) this%with_headers = .true.
+        if (this%n < 1) then
+            this%with_headers = .false.
+            if (present(header)) this%with_headers = .true.
+        end if
 
         if (this%irows_max < 0) then
             call this%add_col_integer(col)
@@ -716,7 +722,10 @@ contains
 
         if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_len
 
-        if (this%n < 1 .and. present(header)) this%with_headers = .true.
+        if (this%n < 1) then
+            this%with_headers = .false.
+            if (present(header)) this%with_headers = .true.
+        end if
 
         if (this%lrows_max < 0) then
             call this%add_col_logical(col)
@@ -758,7 +767,10 @@ contains
 
         if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_len
 
-        if (this%n < 1 .and. present(header)) this%with_headers = .true.
+        if (this%n < 1) then
+            this%with_headers = .false.
+            if (present(header)) this%with_headers = .true.
+        end if
 
         if (this%chrows_max < 0) then
             call this%add_col_character(col)
@@ -800,7 +812,10 @@ contains
 
         if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_len
 
-        if (this%n < 1 .and. present(header)) this%with_headers = .true.
+        if (this%n < 1) then
+            this%with_headers = .false.
+            if (present(header)) this%with_headers = .true.
+        end if
 
         if (this%crows_max < 0) then
             call this%add_col_complex(col)
@@ -1111,7 +1126,10 @@ contains
 
         if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_size
 
-        if (this%n < 1 .and. present(header)) this%with_headers = .true.
+        if (this%n < 1) then
+            this%with_headers = .false.
+            if (present(header)) this%with_headers = .true.
+        end if
 
         if (this%rrows_max < 0) then
             call this%add_empty_col_real(col_size)
@@ -1150,7 +1168,10 @@ contains
 
         if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_size
 
-        if (this%n < 1 .and. present(header)) this%with_headers = .true.
+        if (this%n < 1) then
+            this%with_headers = .false.
+            if (present(header)) this%with_headers = .true.
+        end if
 
         if (this%irows_max < 0) then
             call this%add_empty_col_integer(col_size)
@@ -1189,7 +1210,10 @@ contains
 
         if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_size
 
-        if (this%n < 1 .and. present(header)) this%with_headers = .true.
+        if (this%n < 1) then
+            this%with_headers = .false.
+            if (present(header)) this%with_headers = .true.
+        end if
 
         if (this%lrows_max < 0) then
             call this%add_empty_col_logical(col_size)
@@ -1228,7 +1252,10 @@ contains
 
         if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_size
 
-        if (this%n < 1 .and. present(header)) this%with_headers = .true.
+        if (this%n < 1) then
+            this%with_headers = .false.
+            if (present(header)) this%with_headers = .true.
+        end if
 
         if (this%chrows_max < 0) then
             call this%add_empty_col_character(col_size)
@@ -1267,7 +1294,10 @@ contains
 
         if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_size
 
-        if (this%n < 1 .and. present(header)) this%with_headers = .true.
+        if (this%n < 1) then
+            this%with_headers = .false.
+            if (present(header)) this%with_headers = .true.
+        end if
 
         if (this%crows_max < 0) then
             call this%add_empty_col_complex(col_size)

--- a/src/df_fortranDF.f90
+++ b/src/df_fortranDF.f90
@@ -45,7 +45,8 @@ module df_fortranDF
         procedure,public :: destroy => df_destructor
 
         procedure,public :: ncols => df_get_num_cols
-        procedure,public :: nrows => df_get_num_rows
+        procedure :: df_get_num_rows, df_get_nrows_max
+        generic,public :: nrows => df_get_num_rows, df_get_nrows_max
         procedure,public :: nreal_cols => df_get_num_cols_real
         procedure,public :: ninteger_cols => df_get_num_cols_integer
         procedure,public :: nlogical_cols => df_get_num_cols_logical
@@ -306,6 +307,14 @@ contains
         num_rows = this%col_lens(ind)
 
     end function df_get_num_rows
+
+    pure function df_get_nrows_max(this) result(nrows_max)
+        class(data_frame),intent(in) :: this
+        integer :: nrows_max
+
+        nrows_max = this%nrows_max
+
+    end function df_get_nrows_max
 
     pure function df_get_col_type_header(this,header) result(dtype)
         class(data_frame),intent(in) :: this
@@ -630,7 +639,10 @@ contains
             error stop 'Different size columns in add col to data_frame'
         end if
 
-        if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_len
+        if (this%nrows_max < 0 .or.     &
+            (.not. this%enforce_length .and. col_len > this%nrows_max)) then
+                this%nrows_max = col_len
+        end if
 
         if (this%n < 1) then
             this%with_headers = .false.
@@ -675,7 +687,10 @@ contains
             error stop 'Different size columns in add col to data_frame'
         end if
 
-        if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_len
+        if (this%nrows_max < 0 .or.      &
+            (.not. this%enforce_length .and. col_len > this%nrows_max)) then
+                this%nrows_max = col_len
+        end if
 
         if (this%n < 1) then
             this%with_headers = .false.
@@ -720,7 +735,10 @@ contains
             error stop 'Different size columns in add col to data_frame'
         end if
 
-        if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_len
+        if (this%nrows_max < 0 .or.      &
+            (.not. this%enforce_length .and. col_len > this%nrows_max)) then
+                this%nrows_max = col_len
+        end if
 
         if (this%n < 1) then
             this%with_headers = .false.
@@ -765,7 +783,10 @@ contains
             error stop 'Different size columns in add col to data_frame'
         end if
 
-        if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_len
+        if (this%nrows_max < 0 .or.      &
+            (.not. this%enforce_length .and. col_len > this%nrows_max)) then
+                this%nrows_max = col_len
+        end if
 
         if (this%n < 1) then
             this%with_headers = .false.
@@ -810,7 +831,10 @@ contains
             error stop 'Different size columns in add col to data_frame'
         end if
 
-        if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_len
+        if (this%nrows_max < 0 .or.      &
+            (.not. this%enforce_length .and. col_len > this%nrows_max)) then
+                this%nrows_max = col_len
+        end if
 
         if (this%n < 1) then
             this%with_headers = .false.
@@ -1124,7 +1148,10 @@ contains
             error stop 'Different size columns in add col to data_frame'
         end if
 
-        if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_size
+        if (this%nrows_max < 0 .or.      &
+            (.not. this%enforce_length .and. col_size > this%nrows_max)) then
+                this%nrows_max = col_size
+        end if
 
         if (this%n < 1) then
             this%with_headers = .false.
@@ -1166,7 +1193,10 @@ contains
             error stop 'Different size columns in add col to data_frame'
         end if
 
-        if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_size
+        if (this%nrows_max < 0 .or.      &
+            (.not. this%enforce_length .and. col_size > this%nrows_max)) then
+                this%nrows_max = col_size
+        end if
 
         if (this%n < 1) then
             this%with_headers = .false.
@@ -1208,7 +1238,10 @@ contains
             error stop 'Different size columns in add col to data_frame'
         end if
 
-        if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_size
+        if (this%nrows_max < 0 .or.      &
+            (.not. this%enforce_length .and. col_size > this%nrows_max)) then
+                this%nrows_max = col_size
+        end if
 
         if (this%n < 1) then
             this%with_headers = .false.
@@ -1250,7 +1283,10 @@ contains
             error stop 'Different size columns in add col to data_frame'
         end if
 
-        if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_size
+        if (this%nrows_max < 0 .or.      &
+            (.not. this%enforce_length .and. col_size > this%nrows_max)) then
+                this%nrows_max = col_size
+        end if
 
         if (this%n < 1) then
             this%with_headers = .false.
@@ -1292,7 +1328,10 @@ contains
             error stop 'Different size columns in add col to data_frame'
         end if
 
-        if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_size
+        if (this%nrows_max < 0 .or.      &
+            (.not. this%enforce_length .and. col_size > this%nrows_max)) then
+                this%nrows_max = col_size
+        end if
 
         if (this%n < 1) then
             this%with_headers = .false.
@@ -2359,23 +2398,35 @@ contains
                 select case (this%type_loc(j,1))
                     case (REAL_NUM)
                         pfmt = "(a2,"//trim(adjustl(rfmt))//",a1)"
-                        rval = this%getr(j,i)
-                        if (i > this%rrows_max) rval = rfill
+                        if (i > this%rrows_max) then
+                            rval = rfill
+                        else
+                            rval = this%getr(j,i)
+                        end if
                         write(io_unit,pfmt,iostat=io_err,advance='no') "| ", rval, " "
                     case (INTEGER_NUM)
                         pfmt = "(a2,"//trim(adjustl(ifmt))//",a1)"
-                        ival = this%geti(j,i)
-                        if (i > this%irows_max) ival = ifill
+                        if (i > this%irows_max) then
+                            ival = ifill
+                        else
+                            ival = this%geti(j,i)
+                        end if
                         write(io_unit,pfmt,iostat=io_err,advance='no') "| ", ival, " "
                     case (LOGICAL_NUM)
                         pfmt = "(a2,"//trim(adjustl(lfmt))//",a1)"
-                        lval = this%getl(j,i)
-                        if (i > this%lrows_max) lval = lfill
+                        if (i > this%lrows_max) then
+                            lval = lfill
+                        else
+                            lval = this%getl(j,i)
+                        end if
                         write(io_unit,pfmt,iostat=io_err,advance='no') "| ", lval, " "
                     case (CHARACTER_NUM)
                         pfmt = "(a2,"//trim(adjustl(chfmt))//",a1)"
-                        chval = this%getch(j,i)
-                        if (i > this%chrows_max) chval = chfill
+                        if (i > this%chrows_max) then
+                            chval = chfill
+                        else
+                            chval = this%getch(j,i)
+                        end if
                         output_char = trim(adjustl(chval))
                         write(io_unit,pfmt,iostat=io_err,advance='no') "| ", adjustr(output_char), " "
                     case (COMPLEX_NUM)

--- a/src/df_fortranDF.f90
+++ b/src/df_fortranDF.f90
@@ -403,18 +403,20 @@ contains
         n = this%n
         rcols = this%rcols
         if (n > 0) then
-            call this%add_type_loc(REAL_NUM,rcols+1)
-            this%n = n + 1
-            this%rcols = rcols + 1
             if (rcols > 0) then
                 allocate(new_cols(this%rrows_max,rcols+1))
                 new_cols(:,1:rcols) = this%rdata
                 new_cols(:end,rcols+1) = col
                 this%rdata = new_cols
+                this%rcols = rcols + 1
+                call this%add_type_loc(REAL_NUM,rcols+1)
             else
                 allocate(this%rdata(this%rrows_max,1))
                 this%rdata(:,1) = col
+                this%rcols = 1
+                call this%add_type_loc(REAL_NUM,1)
             end if
+            this%n = n + 1
         else
             call this%add_type_loc(REAL_NUM,1)
             this%n = 1
@@ -441,18 +443,20 @@ contains
         n = this%n
         icols = this%icols
         if (n > 0) then
-            call this%add_type_loc(INTEGER_NUM,icols+1)
-            this%n = n + 1
-            this%icols = icols + 1
             if (icols > 0) then
                 allocate(new_cols(this%irows_max,icols+1))
                 new_cols(:,1:icols) = this%idata
                 new_cols(:end,icols+1) = col
                 this%idata = new_cols
+                this%icols = icols + 1
+                call this%add_type_loc(INTEGER_NUM,icols+1)
             else
                 allocate(this%idata(this%irows_max,1))
                 this%idata(:end,1) = col
+                this%icols = 1
+                call this%add_type_loc(INTEGER_NUM,1)
             end if
+            this%n = n + 1
         else
             call this%add_type_loc(INTEGER_NUM,1)
             this%n = 1
@@ -479,18 +483,20 @@ contains
         n = this%n
         lcols = this%lcols
         if (n > 0) then
-            call this%add_type_loc(LOGICAL_NUM,lcols+1)
-            this%n = n + 1
-            this%lcols = lcols + 1
             if (lcols > 0) then
                 allocate(new_cols(this%lrows_max,lcols+1))
                 new_cols(:,1:lcols) = this%ldata
                 new_cols(:end,lcols+1) = col
                 this%ldata = new_cols
+                this%lcols = lcols + 1
+                call this%add_type_loc(LOGICAL_NUM,lcols+1)
             else
                 allocate(this%ldata(this%lrows_max,1))
                 this%ldata(:end,1) = col
+                this%lcols = 1
+                call this%add_type_loc(LOGICAL_NUM,1)
             end if
+            this%n = n + 1
         else
             call this%add_type_loc(LOGICAL_NUM,1)
             this%n = 1
@@ -517,18 +523,20 @@ contains
         n = this%n
         chcols = this%chcols
         if (n > 0) then
-            call this%add_type_loc(CHARACTER_NUM,chcols+1)
-            this%n = n + 1
-            this%chcols = chcols + 1
             if (chcols > 0) then
                 allocate(character(this%max_char_len) :: new_cols(this%chrows_max,chcols+1))
                 new_cols(:,1:chcols) = this%chdata
                 new_cols(:end,chcols+1) = col
                 this%chdata = new_cols
+                this%chcols = chcols + 1
+                call this%add_type_loc(CHARACTER_NUM,chcols+1)
             else
                 allocate(character(this%max_char_len) :: this%chdata(this%chrows_max,1))
                 this%chdata(:end,1) = col
+                this%chcols = 1
+                call this%add_type_loc(CHARACTER_NUM,1)
             end if
+            this%n = n + 1
         else
             call this%add_type_loc(CHARACTER_NUM,1)
             this%n = 1
@@ -555,18 +563,19 @@ contains
         n = this%n
         ccols = this%ccols
         if (n > 0) then
-            call this%add_type_loc(COMPLEX_NUM,ccols+1)
-            this%n = n + 1
-            this%ccols = ccols + 1
             if (ccols > 0) then
                 allocate(new_cols(this%crows_max,ccols+1))
                 new_cols(:,1:ccols) = this%cdata
                 new_cols(:end,ccols+1) = col
                 this%cdata = new_cols
+                this%ccols = ccols + 1
             else
                 allocate(this%cdata(this%crows_max,1))
                 this%cdata(:end,1) = col
+                this%ccols = 1
+                call this%add_type_loc(COMPLEX_NUM,1)
             end if
+            this%n = n + 1
         else
             call this%add_type_loc(COMPLEX_NUM,1)
             this%n = 1
@@ -924,16 +933,18 @@ contains
         n = this%n
         rcols = this%rcols
         if (n > 0) then
-            call this%add_type_loc(REAL_NUM,rcols+1)
-            this%n = n + 1
-            this%rcols = rcols + 1
             if (rcols > 0) then
                 allocate(new_cols(this%rrows_max,rcols+1))
                 new_cols(:,1:rcols) = this%rdata
                 this%rdata = new_cols
+                this%rcols = rcols + 1
+                call this%add_type_loc(REAL_NUM,rcols+1)
             else
                 allocate(this%rdata(this%rrows_max,1))
+                this%rcols = 1
+                call this%add_type_loc(REAL_NUM,1)
             end if
+            this%n = n + 1
         else
             call this%add_type_loc(REAL_NUM,1)
             this%n = 1
@@ -958,16 +969,18 @@ contains
         n = this%n
         icols = this%icols
         if (n > 0) then
-            call this%add_type_loc(INTEGER_NUM,icols+1)
-            this%n = n + 1
-            this%icols = icols + 1
             if (icols > 0) then
                 allocate(new_cols(this%irows_max,icols+1))
                 new_cols(:,1:icols) = this%idata
                 this%idata = new_cols
+                this%icols = icols + 1
+                call this%add_type_loc(INTEGER_NUM,icols+1)
             else
                 allocate(this%idata(this%irows_max,1))
+                this%icols = 1
+                call this%add_type_loc(INTEGER_NUM,1)
             end if
+            this%n = n + 1
         else
             call this%add_type_loc(INTEGER_NUM,1)
             this%n = 1
@@ -992,16 +1005,18 @@ contains
         n = this%n
         lcols = this%lcols
         if (n > 0) then
-            call this%add_type_loc(LOGICAL_NUM,lcols+1)
-            this%n = n + 1
-            this%lcols = lcols + 1
             if (lcols > 0) then
                 allocate(new_cols(this%lrows_max,lcols+1))
                 new_cols(:,1:lcols) = this%ldata
                 this%ldata = new_cols
+                this%lcols = lcols + 1
+                call this%add_type_loc(LOGICAL_NUM,lcols+1)
             else
                 allocate(this%ldata(this%lrows_max,1))
+                this%lcols = 1
+                call this%add_type_loc(LOGICAL_NUM,1)
             end if
+            this%n = n + 1
         else
             call this%add_type_loc(LOGICAL_NUM,1)
             this%n = 1
@@ -1026,16 +1041,18 @@ contains
         n = this%n
         chcols = this%chcols
         if (n > 0) then
-            call this%add_type_loc(CHARACTER_NUM,chcols+1)
-            this%n = n + 1
-            this%chcols = chcols + 1
             if (chcols > 0) then
                 allocate(character(this%max_char_len) :: new_cols(this%chrows_max,chcols+1))
                 new_cols(:,1:chcols) = this%chdata
                 this%chdata = new_cols
+                this%chcols = chcols + 1
+                call this%add_type_loc(CHARACTER_NUM,chcols+1)
             else
                 allocate(character(this%max_char_len) :: this%chdata(this%chrows_max,1))
+                this%chcols = 1
+                call this%add_type_loc(CHARACTER_NUM,1)
             end if
+            this%n = n + 1
         else
             call this%add_type_loc(CHARACTER_NUM,1)
             this%n = 1
@@ -1060,16 +1077,18 @@ contains
         n = this%n
         ccols = this%ccols
         if (n > 0) then
-            call this%add_type_loc(COMPLEX_NUM,ccols+1)
-            this%n = n + 1
-            this%ccols = ccols + 1
             if (ccols > 0) then
                 allocate(new_cols(this%crows_max,ccols+1))
                 new_cols(:,1:ccols) = this%cdata
                 this%cdata = new_cols
+                this%ccols = ccols + 1
+                call this%add_type_loc(COMPLEX_NUM,ccols+1)
             else
                 allocate(this%cdata(this%crows_max,1))
+                this%ccols = 1
+                call this%add_type_loc(COMPLEX_NUM,1)
             end if
+            this%n = n + 1
         else
             call this%add_type_loc(COMPLEX_NUM,1)
             this%n = 1

--- a/src/df_fortranDF.f90
+++ b/src/df_fortranDF.f90
@@ -597,12 +597,12 @@ contains
 
         if (.not. this%with_headers) error stop 'cannot add header to data_frame not using headers'
         
-        num_headers = size(this%headers,dim=1)
 
-        if (num_headers < 1) then
+        if (.not. allocated(this%headers)) then
             allocate(character(len=this%max_char_len) :: this%headers(1))
             this%headers(1) = trim(adjustl(header))
         else
+            num_headers = size(this%headers,dim=1)
             if (this%already_header(header)) error stop 'all headers must be unique'
             allocate(character(len(this%headers)) :: new_headers(num_headers+1))
             new_headers(1:num_headers) = this%headers
@@ -1306,6 +1306,11 @@ contains
 
         character(len=this%max_char_len) :: trunc_header
 
+        if (.not. allocated(this%headers)) then
+            already_header = .false.
+            return
+        end if
+
         trunc_header = trim(adjustl(header))
         if (findloc(this%headers,trunc_header,dim=1) > 0) then
             already_header = .true.
@@ -1329,7 +1334,12 @@ contains
         if (this%type_loc(i,1) /= REAL_NUM) error stop 'column is not of real type'
         ind = this%type_loc(i,2)
 
-        end = this%col_lens(i)
+        if (.not. this%enforce_length) then
+            end = this%col_lens(i)
+        else
+            end = this%nrows_max
+        end if
+        
         if (present(full)) then
             if (full) end = this%rrows_max
         end if
@@ -1349,7 +1359,12 @@ contains
         if (this%type_loc(i,1) /= INTEGER_NUM) error stop 'column is not of integer type'
         ind = this%type_loc(i,2)
 
-        end = this%col_lens(i)
+        if (.not. this%enforce_length) then
+            end = this%col_lens(i)
+        else
+            end = this%nrows_max
+        end if
+
         if (present(full)) then
             if (full) end = this%irows_max
         end if
@@ -1369,7 +1384,12 @@ contains
         if (this%type_loc(i,1) /= LOGICAL_NUM) error stop 'column is not of logical type'
         ind = this%type_loc(i,2)
 
-        end = this%col_lens(i)
+        if (.not. this%enforce_length) then
+            end = this%col_lens(i)
+        else
+            end = this%nrows_max
+        end if
+
         if (present(full)) then
             if (full) end = this%lrows_max
         end if
@@ -1389,7 +1409,12 @@ contains
         if (this%type_loc(i,1) /= CHARACTER_NUM) error stop 'column is not of character type'
         ind = this%type_loc(i,2)
 
-        end = this%col_lens(i)
+        if (.not. this%enforce_length) then
+            end = this%col_lens(i)
+        else
+            end = this%nrows_max
+        end if
+
         if (present(full)) then
             if (full) end = this%chrows_max
         end if
@@ -1409,7 +1434,12 @@ contains
         if (this%type_loc(i,1) /= COMPLEX_NUM) error stop 'column is not of complex type'
         ind = this%type_loc(i,2)
 
-        end = this%col_lens(i)
+        if (.not. this%enforce_length) then
+            end = this%col_lens(i)
+        else
+            end = this%nrows_max
+        end if
+
         if (present(full)) then
             if (full) end = this%crows_max
         end if
@@ -1442,7 +1472,12 @@ contains
         if (this%type_loc(ind,1) /= REAL_NUM) error stop 'column is not of real type'
         data_index = this%type_loc(ind,2)
 
-        end = this%col_lens(ind)
+        if (.not. this%enforce_length) then
+            end = this%col_lens(ind)
+        else
+            end = this%nrows_max
+        end if
+
         if (present(full)) then
             if (full) end = this%rrows_max
         end if
@@ -1470,7 +1505,12 @@ contains
         if (this%type_loc(ind,1) /= INTEGER_NUM) error stop 'column is not of integer type'
         data_index = this%type_loc(ind,2)
 
-        end = this%col_lens(ind)
+        if (.not. this%enforce_length) then
+            end = this%col_lens(ind)
+        else
+            end = this%nrows_max
+        end if
+        
         if (present(full)) then
             if (full) end = this%irows_max
         end if
@@ -1498,7 +1538,12 @@ contains
         if (this%type_loc(ind,1) /= LOGICAL_NUM) error stop 'column is not of logical type'
         data_index = this%type_loc(ind,2)
 
-        end = this%col_lens(ind)
+        if (.not. this%enforce_length) then
+            end = this%col_lens(ind)
+        else
+            end = this%nrows_max
+        end if
+        
         if (present(full)) then
             if (full) end = this%lrows_max
         end if
@@ -1526,7 +1571,12 @@ contains
         if (this%type_loc(ind,1) /= CHARACTER_NUM) error stop 'column is not of character type'
         data_index = this%type_loc(ind,2)
 
-        end = this%col_lens(ind)
+        if (.not. this%enforce_length) then
+            end = this%col_lens(ind)
+        else
+            end = this%nrows_max
+        end if
+        
         if (present(full)) then
             if (full) end = this%chrows_max
         end if
@@ -1554,7 +1604,12 @@ contains
         if (this%type_loc(ind,1) /= COMPLEX_NUM) error stop 'column is not of complex type'
         data_index = this%type_loc(ind,2)
 
-        end = this%col_lens(ind)
+        if (.not. this%enforce_length) then
+            end = this%col_lens(ind)
+        else
+            end = this%nrows_max
+        end if
+        
         if (present(full)) then
             if (full) end = this%crows_max
         end if

--- a/src/df_fortranDF.f90
+++ b/src/df_fortranDF.f90
@@ -392,11 +392,13 @@ contains
         real(rk),dimension(:),intent(in) :: col
 
         real(rk),dimension(:,:),allocatable :: new_cols
-        integer :: n, rcols
+        integer :: n, rcols, end
 
         if (.not. this%initialized) call this%new()
 
         if (this%rrows_max < 0) this%rrows_max = size(col,dim=1)
+
+        end = size(col,dim=1)
 
         n = this%n
         rcols = this%rcols
@@ -407,7 +409,7 @@ contains
             if (rcols > 0) then
                 allocate(new_cols(this%rrows_max,rcols+1))
                 new_cols(:,1:rcols) = this%rdata
-                new_cols(:,rcols+1) = col
+                new_cols(:end,rcols+1) = col
                 this%rdata = new_cols
             else
                 allocate(this%rdata(this%rrows_max,1))
@@ -418,7 +420,7 @@ contains
             this%n = 1
             this%rcols = 1
             allocate(this%rdata(this%rrows_max,1))
-            this%rdata(:,1) = col
+            this%rdata(:end,1) = col
         end if
 
     end subroutine add_col_real
@@ -428,11 +430,13 @@ contains
         integer(ik),dimension(:),intent(in) :: col
 
         integer(ik),dimension(:,:),allocatable :: new_cols
-        integer :: n, icols
+        integer :: n, icols, end
 
         if (.not. this%initialized) call this%new()
 
         if (this%irows_max < 0) this%irows_max = size(col,dim=1)
+
+        end = size(col,dim=1)
 
         n = this%n
         icols = this%icols
@@ -443,11 +447,11 @@ contains
             if (icols > 0) then
                 allocate(new_cols(this%irows_max,icols+1))
                 new_cols(:,1:icols) = this%idata
-                new_cols(:,icols+1) = col
+                new_cols(:end,icols+1) = col
                 this%idata = new_cols
             else
                 allocate(this%idata(this%irows_max,1))
-                this%idata(:,1) = col
+                this%idata(:end,1) = col
             end if
         else
             call this%add_type_loc(INTEGER_NUM,1)
@@ -464,11 +468,13 @@ contains
         logical,dimension(:),intent(in) :: col
 
         logical,dimension(:,:),allocatable :: new_cols
-        integer :: n, lcols
+        integer :: n, lcols, end
 
         if (.not. this%initialized) call this%new()
 
         if (this%lrows_max < 0) this%lrows_max = size(col,dim=1)
+
+        end = size(col,dim=1)
 
         n = this%n
         lcols = this%lcols
@@ -479,11 +485,11 @@ contains
             if (lcols > 0) then
                 allocate(new_cols(this%lrows_max,lcols+1))
                 new_cols(:,1:lcols) = this%ldata
-                new_cols(:,lcols+1) = col
+                new_cols(:end,lcols+1) = col
                 this%ldata = new_cols
             else
                 allocate(this%ldata(this%lrows_max,1))
-                this%ldata(:,1) = col
+                this%ldata(:end,1) = col
             end if
         else
             call this%add_type_loc(LOGICAL_NUM,1)
@@ -500,11 +506,13 @@ contains
         character(len=*),dimension(:),intent(in) :: col
 
         character(len=:),dimension(:,:),allocatable :: new_cols
-        integer :: n,chcols
+        integer :: n,chcols, end
 
         if (.not. this%initialized) call this%new()
 
         if (this%chrows_max < 0) this%chrows_max = size(col,dim=1)
+
+        end = size(col,dim=1)
 
         n = this%n
         chcols = this%chcols
@@ -515,11 +523,11 @@ contains
             if (chcols > 0) then
                 allocate(character(this%max_char_len) :: new_cols(this%chrows_max,chcols+1))
                 new_cols(:,1:chcols) = this%chdata
-                new_cols(:,chcols+1) = col
+                new_cols(:end,chcols+1) = col
                 this%chdata = new_cols
             else
                 allocate(character(this%max_char_len) :: this%chdata(this%chrows_max,1))
-                this%chdata(:,1) = col
+                this%chdata(:end,1) = col
             end if
         else
             call this%add_type_loc(CHARACTER_NUM,1)
@@ -536,11 +544,13 @@ contains
         complex(rk),dimension(:),intent(in) :: col
 
         complex(rk),dimension(:,:),allocatable :: new_cols
-        integer :: n, ccols
+        integer :: n, ccols, end
 
         if (.not. this%initialized) call this%new()
 
         if (this%crows_max < 0) this%crows_max = size(col,dim=1)
+
+        end = size(col,dim=1)
 
         n = this%n
         ccols = this%ccols
@@ -551,11 +561,11 @@ contains
             if (ccols > 0) then
                 allocate(new_cols(this%crows_max,ccols+1))
                 new_cols(:,1:ccols) = this%cdata
-                new_cols(:,ccols+1) = col
+                new_cols(:end,ccols+1) = col
                 this%cdata = new_cols
             else
                 allocate(this%cdata(this%crows_max,1))
-                this%cdata(:,1) = col
+                this%cdata(:end,1) = col
             end if
         else
             call this%add_type_loc(COMPLEX_NUM,1)
@@ -613,6 +623,8 @@ contains
 
         if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_len
 
+        if (this%n < 1 .and. present(header)) this%with_headers = .true.
+
         if (this%rrows_max < 0) then
             call this%add_col_real(col)
             if (.not. this%enforce_length) call this%add_col_len(col_len)
@@ -652,6 +664,8 @@ contains
         end if
 
         if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_len
+
+        if (this%n < 1 .and. present(header)) this%with_headers = .true.
 
         if (this%irows_max < 0) then
             call this%add_col_integer(col)
@@ -693,6 +707,8 @@ contains
 
         if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_len
 
+        if (this%n < 1 .and. present(header)) this%with_headers = .true.
+
         if (this%lrows_max < 0) then
             call this%add_col_logical(col)
             if (.not. this%enforce_length) call this%add_col_len(col_len)
@@ -733,6 +749,8 @@ contains
 
         if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_len
 
+        if (this%n < 1 .and. present(header)) this%with_headers = .true.
+
         if (this%chrows_max < 0) then
             call this%add_col_character(col)
             if (.not. this%enforce_length) call this%add_col_len(col_len)
@@ -772,6 +790,8 @@ contains
         end if
 
         if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_len
+
+        if (this%n < 1 .and. present(header)) this%with_headers = .true.
 
         if (this%crows_max < 0) then
             call this%add_col_complex(col)
@@ -1072,6 +1092,8 @@ contains
 
         if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_size
 
+        if (this%n < 1 .and. present(header)) this%with_headers = .true.
+
         if (this%rrows_max < 0) then
             call this%add_empty_col_real(col_size)
             if (.not. this%enforce_length) call this%add_col_len(col_size)
@@ -1108,6 +1130,8 @@ contains
         end if
 
         if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_size
+
+        if (this%n < 1 .and. present(header)) this%with_headers = .true.
 
         if (this%irows_max < 0) then
             call this%add_empty_col_integer(col_size)
@@ -1146,6 +1170,8 @@ contains
 
         if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_size
 
+        if (this%n < 1 .and. present(header)) this%with_headers = .true.
+
         if (this%lrows_max < 0) then
             call this%add_empty_col_logical(col_size)
             if (.not. this%enforce_length) call this%add_col_len(col_size)
@@ -1183,6 +1209,8 @@ contains
 
         if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_size
 
+        if (this%n < 1 .and. present(header)) this%with_headers = .true.
+
         if (this%chrows_max < 0) then
             call this%add_empty_col_character(col_size)
             if (.not. this%enforce_length) call this%add_col_len(col_size)
@@ -1219,6 +1247,8 @@ contains
         end if
 
         if (this%enforce_length .and. this%nrows_max < 0) this%nrows_max = col_size
+
+        if (this%n < 1 .and. present(header)) this%with_headers = .true.
 
         if (this%crows_max < 0) then
             call this%add_empty_col_complex(col_size)
@@ -2172,19 +2202,19 @@ contains
         integer :: i, j
         integer :: num_cols, len_cols
 
-        real(rk) :: rval
-        integer(ik) :: ival
-        logical :: lval
-        character(len=this%max_char_len) :: chval
-        complex(rk) :: cval
+        real(rk) :: rval, rfill
+        integer(ik) :: ival, ifill
+        logical :: lval, lfill
+        character(len=this%max_char_len) :: chval, chfill
+        complex(rk) :: cval, cfill
 
-
-        real(rk),parameter :: rfill = 0.0_rk
-        integer(ik),parameter :: ifill = 0
-        logical,parameter :: lfill = .false.
-        character(len=this%max_char_len),parameter :: chfill = "null"
-        complex(rk),parameter :: cfill = 0.0_rk
         logical :: outside_col
+
+        rfill = 0.0_rk
+        ifill = 0
+        lfill = .false.
+        chfill = trim(adjustl("null"))
+        cfill = 0.0_rk
 
 
         if (present(unit)) then

--- a/src/df_fortranDF.f90
+++ b/src/df_fortranDF.f90
@@ -2492,6 +2492,10 @@ contains
 
         integer :: i, offset
 
+        if (.not. this%enforce_length) then
+            error stop 'currently only fixed-length data frames are supported for reading from file'
+        end if
+
         open(newunit=unit,file=trim(adjustl(filename)),status="old",action="read",iostat=io_err)
         if (io_err /= 0) then
             err_msg = err_msg_io_open//" "//trim(adjustl(filename))

--- a/src/df_fortranDF.f90
+++ b/src/df_fortranDF.f90
@@ -1269,85 +1269,118 @@ contains
 
 ! ~~~~ Get Column DF with index
 
-    pure function df_get_col_ind_real(this,i) result(col)
+    pure function df_get_col_ind_real(this,i,full) result(col)
         class(data_frame),intent(in) :: this
         integer,intent(in) :: i
-        real(rk),dimension(this%col_size) :: col
+        logical,intent(in),optional :: full ! return full column
+        real(rk),dimension(:),allocatable :: col
 
-        integer :: ind
+        integer :: ind, end
 
         if (this%type_loc(i,1) /= REAL_NUM) error stop 'column is not of real type'
         ind = this%type_loc(i,2)
 
-        col = this%rdata(:,ind)
+        end = this%col_lens(i)
+        if (present(full)) then
+            if (full) end = this%rrows_max
+        end if
+
+        col = this%rdata(:end,ind)
 
     end function df_get_col_ind_real
 
-    pure function df_get_col_ind_integer(this,i) result(col)
+    pure function df_get_col_ind_integer(this,i,full) result(col)
         class(data_frame),intent(in) :: this
         integer,intent(in) :: i
-        integer(ik),dimension(this%col_size) :: col
+        logical,intent(in),optional :: full ! return full column
+        integer(ik),dimension(:),allocatable :: col
 
-        integer :: ind
+        integer :: ind, end
 
         if (this%type_loc(i,1) /= INTEGER_NUM) error stop 'column is not of integer type'
         ind = this%type_loc(i,2)
 
-        col = this%idata(:,ind)
+        end = this%col_lens(i)
+        if (present(full)) then
+            if (full) end = this%irows_max
+        end if
+
+        col = this%idata(:end,ind)
 
     end function df_get_col_ind_integer
 
-    pure function df_get_col_ind_logical(this,i) result(col)
+    pure function df_get_col_ind_logical(this,i,full) result(col)
         class(data_frame),intent(in) :: this
         integer,intent(in) :: i
-        logical,dimension(this%col_size) :: col
+        logical,intent(in),optional :: full ! return full column
+        logical,dimension(:),allocatable :: col
 
-        integer :: ind
+        integer :: ind, end
 
         if (this%type_loc(i,1) /= LOGICAL_NUM) error stop 'column is not of logical type'
         ind = this%type_loc(i,2)
 
-        col = this%ldata(:,ind)
+        end = this%col_lens(i)
+        if (present(full)) then
+            if (full) end = this%lrows_max
+        end if
+
+        col = this%ldata(:end,ind)
 
     end function df_get_col_ind_logical
 
-    pure function df_get_col_ind_character(this,i) result(col)
+    pure function df_get_col_ind_character(this,i,full) result(col)
         class(data_frame),intent(in) :: this
         integer,intent(in) :: i
+        logical,intent(in),optional :: full ! return full column
         character(len=:),dimension(:),allocatable :: col
 
-        integer :: ind
+        integer :: ind, end
 
         if (this%type_loc(i,1) /= CHARACTER_NUM) error stop 'column is not of character type'
         ind = this%type_loc(i,2)
 
-        col = this%chdata(:,ind)
+        end = this%col_lens(i)
+        if (present(full)) then
+            if (full) end = this%chrows_max
+        end if
+
+        col = this%chdata(:end,ind)
 
     end function df_get_col_ind_character
 
-    pure function df_get_col_ind_complex(this,i) result(col)
+    pure function df_get_col_ind_complex(this,i,full) result(col)
         class(data_frame),intent(in) :: this
         integer,intent(in) :: i
-        complex(rk),dimension(this%col_size) :: col
+        logical,intent(in),optional :: full ! return full column
+        complex(rk),dimension(:),allocatable :: col
 
-        integer :: ind
+        integer :: ind, end
 
         if (this%type_loc(i,1) /= COMPLEX_NUM) error stop 'column is not of complex type'
         ind = this%type_loc(i,2)
 
-        col = this%cdata(:,ind)
+        end = this%col_lens(i)
+        if (present(full)) then
+            if (full) end = this%crows_max
+        end if
+
+        col = this%cdata(:end,ind)
 
     end function df_get_col_ind_complex
 
 
 ! ~~~~ Get Column DF from header
 
-    pure function df_get_col_header_real(this,header) result(col)
+    pure function df_get_col_header_real(this,header,full) result(col)
         class(data_frame),intent(in) :: this
         character(len=*),intent(in) :: header
-        real(rk),dimension(this%col_size) :: col
+        logical,intent(in),optional :: full ! return full column
+        real(rk),dimension(:),allocatable :: col
 
-        integer :: ind, data_index
+        ! should be refactored so that `data_index` is `ind`, and `ind` is `i` to match index version
+        ! of function
+        integer :: ind, data_index, end
         character(len=:),allocatable :: trunc_header
 
         if (.not. this%with_headers) error stop "data frame has no headers to look up"
@@ -1359,16 +1392,23 @@ contains
 
         if (this%type_loc(ind,1) /= REAL_NUM) error stop 'column is not of real type'
         data_index = this%type_loc(ind,2)
-        col = this%rdata(:,data_index)
+
+        end = this%col_lens(ind)
+        if (present(full)) then
+            if (full) end = this%rrows_max
+        end if
+
+        col = this%rdata(:end,data_index)
 
     end function df_get_col_header_real
 
-    pure function df_get_col_header_integer(this,header) result(col)
+    pure function df_get_col_header_integer(this,header,full) result(col)
         class(data_frame),intent(in) :: this
         character(len=*),intent(in) :: header
-        integer(ik),dimension(this%col_size) :: col
+        logical,intent(in),optional :: full ! return full column
+        integer(ik),dimension(:),allocatable :: col
 
-        integer :: ind, data_index
+        integer :: ind, data_index, end
         character(len=:),allocatable :: trunc_header
 
         if (.not. this%with_headers) error stop "data frame has no headers to look up"
@@ -1380,16 +1420,23 @@ contains
 
         if (this%type_loc(ind,1) /= INTEGER_NUM) error stop 'column is not of integer type'
         data_index = this%type_loc(ind,2)
-        col = this%idata(:,data_index)
+
+        end = this%col_lens(ind)
+        if (present(full)) then
+            if (full) end = this%irows_max
+        end if
+
+        col = this%idata(:end,data_index)
 
     end function df_get_col_header_integer
 
-    pure function df_get_col_header_logical(this,header) result(col)
+    pure function df_get_col_header_logical(this,header,full) result(col)
         class(data_frame),intent(in) :: this
         character(len=*),intent(in) :: header
-        logical,dimension(this%col_size) :: col
+        logical,intent(in),optional :: full ! return full column
+        logical,dimension(:),allocatable :: col
 
-        integer :: ind, data_index
+        integer :: ind, data_index, end
         character(len=:),allocatable :: trunc_header
 
         if (.not. this%with_headers) error stop "data frame has no headers to look up"
@@ -1401,16 +1448,23 @@ contains
 
         if (this%type_loc(ind,1) /= LOGICAL_NUM) error stop 'column is not of logical type'
         data_index = this%type_loc(ind,2)
-        col = this%ldata(:,data_index)
+
+        end = this%col_lens(ind)
+        if (present(full)) then
+            if (full) end = this%lrows_max
+        end if
+
+        col = this%ldata(:end,data_index)
 
     end function df_get_col_header_logical
 
-    pure function df_get_col_header_character(this,header) result(col)
+    pure function df_get_col_header_character(this,header,full) result(col)
         class(data_frame),intent(in) :: this
         character(len=*),intent(in) :: header
+        logical,intent(in),optional :: full ! return full column
         character(len=:),dimension(:),allocatable :: col
 
-        integer :: ind, data_index
+        integer :: ind, data_index, end
         character(len=:),allocatable :: trunc_header
 
         if (.not. this%with_headers) error stop "data frame has no headers to look up"
@@ -1422,16 +1476,23 @@ contains
 
         if (this%type_loc(ind,1) /= CHARACTER_NUM) error stop 'column is not of character type'
         data_index = this%type_loc(ind,2)
-        col = this%chdata(:,data_index)
+
+        end = this%col_lens(ind)
+        if (present(full)) then
+            if (full) end = this%chrows_max
+        end if
+
+        col = this%chdata(:end,data_index)
 
     end function df_get_col_header_character
 
-    pure function df_get_col_header_complex(this,header) result(col)
+    pure function df_get_col_header_complex(this,header,full) result(col)
         class(data_frame),intent(in) :: this
         character(len=*),intent(in) :: header
-        complex(rk),dimension(this%col_size) :: col
+        logical,intent(in),optional :: full ! return full column
+        complex(rk),dimension(:),allocatable :: col
 
-        integer :: ind, data_index
+        integer :: ind, data_index, end
         character(len=:),allocatable :: trunc_header
 
         if (.not. this%with_headers) error stop "data frame has no headers to look up"
@@ -1443,7 +1504,13 @@ contains
 
         if (this%type_loc(ind,1) /= COMPLEX_NUM) error stop 'column is not of complex type'
         data_index = this%type_loc(ind,2)
-        col = this%cdata(:,data_index)
+
+        end = this%col_lens(ind)
+        if (present(full)) then
+            if (full) end = this%crows_max
+        end if
+
+        col = this%cdata(:end,data_index)
 
     end function df_get_col_header_complex
 

--- a/src/df_types.f90
+++ b/src/df_types.f90
@@ -1,8 +1,8 @@
 module df_types
     implicit none
 
-    integer,parameter,public :: INTEGER_NUM = 1,       &
-                                REAL_NUM = 2,          &
+    integer,parameter,public :: REAL_NUM = 1,       &
+                                INTEGER_NUM = 2,          &
                                 LOGICAL_NUM = 3,       &
                                 CHARACTER_NUM = 4,     &
                                 COMPLEX_NUM = 5


### PR DESCRIPTION
Added the ability to use variable size columns. 

Data frames are initialized with fixed-length columns by default, but variable length columns can be chosen by including `enforce_length=.false.` when initializing data_frame (ie `call df%new(enforce_length=.false.)`). 

Data arrays will be allocated to the length of the longest column of that specific type (ie `rdata` will be allocated to the length of the longest `real` column, `idata` allocated to the longest `integer` column, etc.).

`df_read_df_file`/`df%read()` only supports fixed-length data frames