### PR TITLE
Fix nrows bug

### DIFF
--- a/app/main.f90
+++ b/app/main.f90
@@ -34,9 +34,10 @@ program main
     call df%append(["test1","test2","test3","test4"])
     call df%write()
 
-    print*, "num elems in real col: ", df%nrows(2)
-    print*, "num elems in char col: ", df%nrows(3)
+    print*, "num elems in real col:   ", df%nrows(2)
+    print*, "num elems in char col:   ", df%nrows(3)
     print*, "most num elems in a col: ", df%nrows()
+    print*, "max num rows:            ", df%nrows()
 
     call df%destroy()
 

--- a/src/df_fortranDF.f90
+++ b/src/df_fortranDF.f90
@@ -208,7 +208,7 @@ contains
         this%lrows_max = -1
         this%chrows_max = -1
         this%crows_max = -1
-        if (this%enforce_length) this%nrows_max = -1
+        this%nrows_max = -1
 
     end subroutine
 


### PR DESCRIPTION
When using `enforce_length=.false.`, `nrows_max` would not get initialized and depending on what uninitialized value it takes on, might not get updated when `df%append()` is called. This is now fixed and `nrows_max` is always initialized to `-1` in the constructor procedure.