### PR TITLE
Desc var names

### DIFF
--- a/src/df_fortranDF.f90
+++ b/src/df_fortranDF.f90
@@ -367,12 +367,12 @@ contains
 
 ! ~~~~ get header
 
-    function get_header(this,j) result(header)
+    function get_header(this,col_index) result(header)
         class(data_frame),intent(in) :: this
-        integer,intent(in) :: j
+        integer,intent(in) :: col_index
         character(len=this%max_char_len) :: header
 
-        header = this%headers(j)
+        header = this%headers(col_index)
 
     end function get_header
 
@@ -1424,19 +1424,19 @@ contains
 
 ! ~~~~ Get Column DF with index
 
-    pure function df_get_col_ind_real(this,i,full) result(col)
+    pure function df_get_col_ind_real(this,col_index,full) result(col)
         class(data_frame),intent(in) :: this
-        integer,intent(in) :: i
+        integer,intent(in) :: col_index
         logical,intent(in),optional :: full ! return full column
         real(rk),dimension(:),allocatable :: col
 
         integer :: ind, end
 
-        if (this%type_loc(i,1) /= REAL_NUM) error stop 'column is not of real type'
-        ind = this%type_loc(i,2)
+        if (this%type_loc(col_index,1) /= REAL_NUM) error stop 'column is not of real type'
+        ind = this%type_loc(col_index,2)
 
         if (.not. this%enforce_length) then
-            end = this%col_lens(i)
+            end = this%col_lens(col_index)
         else
             end = this%nrows_max
         end if
@@ -1449,19 +1449,19 @@ contains
 
     end function df_get_col_ind_real
 
-    pure function df_get_col_ind_integer(this,i,full) result(col)
+    pure function df_get_col_ind_integer(this,col_index,full) result(col)
         class(data_frame),intent(in) :: this
-        integer,intent(in) :: i
+        integer,intent(in) :: col_index
         logical,intent(in),optional :: full ! return full column
         integer(ik),dimension(:),allocatable :: col
 
         integer :: ind, end
 
-        if (this%type_loc(i,1) /= INTEGER_NUM) error stop 'column is not of integer type'
-        ind = this%type_loc(i,2)
+        if (this%type_loc(col_index,1) /= INTEGER_NUM) error stop 'column is not of integer type'
+        ind = this%type_loc(col_index,2)
 
         if (.not. this%enforce_length) then
-            end = this%col_lens(i)
+            end = this%col_lens(col_index)
         else
             end = this%nrows_max
         end if
@@ -1474,19 +1474,19 @@ contains
 
     end function df_get_col_ind_integer
 
-    pure function df_get_col_ind_logical(this,i,full) result(col)
+    pure function df_get_col_ind_logical(this,col_index,full) result(col)
         class(data_frame),intent(in) :: this
-        integer,intent(in) :: i
+        integer,intent(in) :: col_index
         logical,intent(in),optional :: full ! return full column
         logical,dimension(:),allocatable :: col
 
         integer :: ind, end
 
-        if (this%type_loc(i,1) /= LOGICAL_NUM) error stop 'column is not of logical type'
-        ind = this%type_loc(i,2)
+        if (this%type_loc(col_index,1) /= LOGICAL_NUM) error stop 'column is not of logical type'
+        ind = this%type_loc(col_index,2)
 
         if (.not. this%enforce_length) then
-            end = this%col_lens(i)
+            end = this%col_lens(col_index)
         else
             end = this%nrows_max
         end if
@@ -1499,19 +1499,19 @@ contains
 
     end function df_get_col_ind_logical
 
-    pure function df_get_col_ind_character(this,i,full) result(col)
+    pure function df_get_col_ind_character(this,col_index,full) result(col)
         class(data_frame),intent(in) :: this
-        integer,intent(in) :: i
+        integer,intent(in) :: col_index
         logical,intent(in),optional :: full ! return full column
         character(len=:),dimension(:),allocatable :: col
 
         integer :: ind, end
 
-        if (this%type_loc(i,1) /= CHARACTER_NUM) error stop 'column is not of character type'
-        ind = this%type_loc(i,2)
+        if (this%type_loc(col_index,1) /= CHARACTER_NUM) error stop 'column is not of character type'
+        ind = this%type_loc(col_index,2)
 
         if (.not. this%enforce_length) then
-            end = this%col_lens(i)
+            end = this%col_lens(col_index)
         else
             end = this%nrows_max
         end if
@@ -1524,19 +1524,19 @@ contains
 
     end function df_get_col_ind_character
 
-    pure function df_get_col_ind_complex(this,i,full) result(col)
+    pure function df_get_col_ind_complex(this,col_index,full) result(col)
         class(data_frame),intent(in) :: this
-        integer,intent(in) :: i
+        integer,intent(in) :: col_index
         logical,intent(in),optional :: full ! return full column
         complex(rk),dimension(:),allocatable :: col
 
         integer :: ind, end
 
-        if (this%type_loc(i,1) /= COMPLEX_NUM) error stop 'column is not of complex type'
-        ind = this%type_loc(i,2)
+        if (this%type_loc(col_index,1) /= COMPLEX_NUM) error stop 'column is not of complex type'
+        ind = this%type_loc(col_index,2)
 
         if (.not. this%enforce_length) then
-            end = this%col_lens(i)
+            end = this%col_lens(col_index)
         else
             end = this%nrows_max
         end if
@@ -1722,83 +1722,83 @@ contains
 
 ! ~~~~ Get Single Val DF
 
-    pure function df_get_val_real(this,i,j) result(val)
+    pure function df_get_val_real(this,col_index,row_index) result(val)
         class(data_frame),intent(in) :: this
-        integer,intent(in) :: i,j
+        integer,intent(in) :: col_index,row_index
         real(rk) :: val
 
         integer :: ind
 
-        if (this%type_loc(i,1) /= REAL_NUM) error stop 'column is not of real type'
-        ind = this%type_loc(i,2)
+        if (this%type_loc(col_index,1) /= REAL_NUM) error stop 'column is not of real type'
+        ind = this%type_loc(col_index,2)
 
-        val = this%rdata(j,ind)
+        val = this%rdata(row_index,ind)
 
     end function df_get_val_real
 
-    pure function df_get_val_integer(this,i,j) result(val)
+    pure function df_get_val_integer(this,col_index,row_index) result(val)
         class(data_frame),intent(in) :: this
-        integer,intent(in) :: i,j
+        integer,intent(in) :: col_index,row_index
         integer(ik) :: val
 
         integer :: ind
 
-        if (this%type_loc(i,1) /= INTEGER_NUM) error stop 'column is not of integer type'
-        ind = this%type_loc(i,2)
+        if (this%type_loc(col_index,1) /= INTEGER_NUM) error stop 'column is not of integer type'
+        ind = this%type_loc(col_index,2)
 
-        val = this%idata(j,ind)
+        val = this%idata(row_index,ind)
 
     end function df_get_val_integer
     
-    pure function df_get_val_logical(this,i,j) result(val)
+    pure function df_get_val_logical(this,col_index,row_index) result(val)
         class(data_frame),intent(in) :: this
-        integer,intent(in) :: i,j
+        integer,intent(in) :: col_index,row_index
         logical :: val
 
         integer :: ind
 
-        if (this%type_loc(i,1) /= LOGICAL_NUM) error stop 'column is not of logical type'
-        ind = this%type_loc(i,2)
+        if (this%type_loc(col_index,1) /= LOGICAL_NUM) error stop 'column is not of logical type'
+        ind = this%type_loc(col_index,2)
 
-        val = this%ldata(j,ind)
+        val = this%ldata(row_index,ind)
 
     end function df_get_val_logical
 
-    pure function df_get_val_character(this,i,j) result(val)
+    pure function df_get_val_character(this,col_index,row_index) result(val)
         class(data_frame),intent(in) :: this
-        integer,intent(in) :: i,j
+        integer,intent(in) :: col_index,row_index
         character(len=:),allocatable :: val
 
         integer :: ind
 
-        if (this%type_loc(i,1) /= CHARACTER_NUM) error stop 'column is not of character type'
-        ind = this%type_loc(i,2)
+        if (this%type_loc(col_index,1) /= CHARACTER_NUM) error stop 'column is not of character type'
+        ind = this%type_loc(col_index,2)
 
-        val = this%chdata(j,ind)
+        val = this%chdata(row_index,ind)
 
     end function df_get_val_character
 
-    pure function df_get_val_complex(this,i,j) result(val)
+    pure function df_get_val_complex(this,col_index,row_index) result(val)
         class(data_frame),intent(in) :: this
-        integer,intent(in) :: i,j
+        integer,intent(in) :: col_index,row_index
         complex(rk) :: val
 
         integer :: ind
 
-        if (this%type_loc(i,1) /= COMPLEX_NUM) error stop 'column is not of complex type'
-        ind = this%type_loc(i,2)
+        if (this%type_loc(col_index,1) /= COMPLEX_NUM) error stop 'column is not of complex type'
+        ind = this%type_loc(col_index,2)
 
-        val = this%cdata(j,ind)
+        val = this%cdata(row_index,ind)
 
     end function df_get_val_complex
 
 
 ! ~~~~ Get single value from header
 
-    pure function df_get_val_header_real(this,header,j) result(val)
+    pure function df_get_val_header_real(this,header,row_index) result(val)
         class(data_frame),intent(in) :: this
         character(len=*),intent(in) :: header
-        integer,intent(in) :: j
+        integer,intent(in) :: row_index
         real(rk) :: val
 
         integer :: ind, data_index
@@ -1813,15 +1813,15 @@ contains
 
         if (this%type_loc(ind,1) /= REAL_NUM) error stop 'column is not of real type'
         data_index = this%type_loc(ind,2)
-        val = this%rdata(j,data_index)
+        val = this%rdata(row_index,data_index)
 
 
     end function df_get_val_header_real
 
-    pure function df_get_val_header_integer(this,header,j) result(val)
+    pure function df_get_val_header_integer(this,header,row_index) result(val)
         class(data_frame),intent(in) :: this
         character(len=*),intent(in) :: header
-        integer,intent(in) :: j
+        integer,intent(in) :: row_index
         integer(ik) :: val
 
         integer :: ind, data_index
@@ -1836,14 +1836,14 @@ contains
 
         if (this%type_loc(ind,1) /= INTEGER_NUM) error stop 'column is not of integer type'
         data_index = this%type_loc(ind,2)
-        val = this%idata(j,data_index)
+        val = this%idata(row_index,data_index)
 
     end function df_get_val_header_integer
 
-    pure function df_get_val_header_logical(this,header,j) result(val)
+    pure function df_get_val_header_logical(this,header,row_index) result(val)
         class(data_frame),intent(in) :: this
         character(len=*),intent(in) :: header
-        integer,intent(in) :: j
+        integer,intent(in) :: row_index
         logical :: val
 
         integer :: ind, data_index
@@ -1858,14 +1858,14 @@ contains
 
         if (this%type_loc(ind,1) /= LOGICAL_NUM) error stop 'column is not of logical type'
         data_index = this%type_loc(ind,2)
-        val = this%ldata(j,data_index)
+        val = this%ldata(row_index,data_index)
 
     end function df_get_val_header_logical
 
-    pure function df_get_val_header_character(this,header,j) result(val)
+    pure function df_get_val_header_character(this,header,row_index) result(val)
         class(data_frame),intent(in) :: this
         character(len=*),intent(in) :: header
-        integer,intent(in) :: j
+        integer,intent(in) :: row_index
         character(len=:),allocatable :: val
 
         integer :: ind, data_index
@@ -1880,14 +1880,14 @@ contains
 
         if (this%type_loc(ind,1) /= CHARACTER_NUM) error stop 'column is not of character type'
         data_index = this%type_loc(ind,2)
-        val = this%chdata(j,data_index)
+        val = this%chdata(row_index,data_index)
 
     end function df_get_val_header_character
 
-    pure function df_get_val_header_complex(this,header,j) result(val)
+    pure function df_get_val_header_complex(this,header,row_index) result(val)
         class(data_frame),intent(in) :: this
         character(len=*),intent(in) :: header
-        integer,intent(in) :: j
+        integer,intent(in) :: row_index
         complex(rk) :: val
 
         integer :: ind, data_index
@@ -1902,90 +1902,90 @@ contains
 
         if (this%type_loc(ind,1) /= COMPLEX_NUM) error stop 'column is not of complex type'
         data_index = this%type_loc(ind,2)
-        val = this%cdata(j,data_index)
+        val = this%cdata(row_index,data_index)
 
     end function df_get_val_header_complex
 
 
 ! ~~~~ Change single value of data frame -> two indices
 
-    subroutine df_change_single_indices_real(this,i,j,val)
+    subroutine df_change_single_indices_real(this,col_index,row_index,val)
         class(data_frame),intent(inout) :: this
-        integer,intent(in) :: i,j
+        integer,intent(in) :: col_index,row_index
         real(rk),intent(in) :: val
 
         integer :: ind
 
-        if (this%type_loc(i,1) /= REAL_NUM) error stop 'column is not of real type'
-        ind = this%type_loc(i,2)
+        if (this%type_loc(col_index,1) /= REAL_NUM) error stop 'column is not of real type'
+        ind = this%type_loc(col_index,2)
 
-        this%rdata(j,ind) = val
+        this%rdata(row_index,ind) = val
 
     end subroutine df_change_single_indices_real
 
-    subroutine df_change_single_indices_integer(this,i,j,val)
+    subroutine df_change_single_indices_integer(this,col_index,row_index,val)
         class(data_frame),intent(inout) :: this
-        integer,intent(in) :: i,j
+        integer,intent(in) :: col_index,row_index
         integer(ik),intent(in) :: val
 
         integer :: ind
 
-        if (this%type_loc(i,1) /= INTEGER_NUM) error stop 'column is not of integer type'
-        ind = this%type_loc(i,2)
+        if (this%type_loc(col_index,1) /= INTEGER_NUM) error stop 'column is not of integer type'
+        ind = this%type_loc(col_index,2)
 
-        this%idata(j,ind) = val
+        this%idata(row_index,ind) = val
 
     end subroutine df_change_single_indices_integer
 
-    subroutine df_change_single_indices_logical(this,i,j,val)
+    subroutine df_change_single_indices_logical(this,col_index,row_index,val)
         class(data_frame),intent(inout) :: this
-        integer,intent(in) :: i,j
+        integer,intent(in) :: col_index,row_index
         logical,intent(in) :: val
 
         integer :: ind
 
-        if (this%type_loc(i,1) /= LOGICAL_NUM) error stop 'column is not of logical type'
-        ind = this%type_loc(i,2)
+        if (this%type_loc(col_index,1) /= LOGICAL_NUM) error stop 'column is not of logical type'
+        ind = this%type_loc(col_index,2)
 
-        this%ldata(j,ind) = val
+        this%ldata(row_index,ind) = val
 
     end subroutine df_change_single_indices_logical
 
-    subroutine df_change_single_indices_character(this,i,j,val)
+    subroutine df_change_single_indices_character(this,col_index,row_index,val)
         class(data_frame),intent(inout) :: this
-        integer,intent(in) :: i,j
+        integer,intent(in) :: col_index,row_index
         character(len=*),intent(in) :: val
 
         integer :: ind
 
-        if (this%type_loc(i,1) /= CHARACTER_NUM) error stop 'column is not of character type'
-        ind = this%type_loc(i,2)
+        if (this%type_loc(col_index,1) /= CHARACTER_NUM) error stop 'column is not of character type'
+        ind = this%type_loc(col_index,2)
 
-        this%chdata(j,ind) = val
+        this%chdata(row_index,ind) = val
 
     end subroutine df_change_single_indices_character
 
-    subroutine df_change_single_indices_complex(this,i,j,val)
+    subroutine df_change_single_indices_complex(this,col_index,row_index,val)
         class(data_frame),intent(inout) :: this
-        integer,intent(in) :: i,j
+        integer,intent(in) :: col_index,row_index
         complex(rk),intent(in) :: val
 
         integer :: ind
 
-        if (this%type_loc(i,1) /= COMPLEX_NUM) error stop 'column is not of complex type'
-        ind = this%type_loc(i,2)
+        if (this%type_loc(col_index,1) /= COMPLEX_NUM) error stop 'column is not of complex type'
+        ind = this%type_loc(col_index,2)
 
-        this%cdata(j,ind) = val
+        this%cdata(row_index,ind) = val
 
     end subroutine df_change_single_indices_complex
 
 
 ! ~~~~ Change single value of data frame -> header 
 
-    subroutine df_change_single_header_real(this,header,j,val)
+    subroutine df_change_single_header_real(this,header,row_index,val)
         class(data_frame),intent(inout) :: this
         character(len=*),intent(in) :: header
-        integer,intent(in) :: j
+        integer,intent(in) :: row_index
         real(rk),intent(in) :: val
         
         integer :: ind, data_index
@@ -2000,14 +2000,14 @@ contains
 
         if (this%type_loc(ind,1) /= REAL_NUM) error stop 'column is not of real type'
         data_index = this%type_loc(ind,2)
-        this%rdata(j,data_index) = val
+        this%rdata(row_index,data_index) = val
 
     end subroutine df_change_single_header_real
 
-    subroutine df_change_single_header_integer(this,header,j,val)
+    subroutine df_change_single_header_integer(this,header,row_index,val)
         class(data_frame),intent(inout) :: this
         character(len=*),intent(in) :: header
-        integer,intent(in) :: j
+        integer,intent(in) :: row_index
         integer(ik),intent(in) :: val
         
         integer :: ind, data_index
@@ -2022,14 +2022,14 @@ contains
 
         if (this%type_loc(ind,1) /= INTEGER_NUM) error stop 'column is not of integer type'
         data_index = this%type_loc(ind,2)
-        this%idata(j,data_index) = val
+        this%idata(row_index,data_index) = val
 
     end subroutine df_change_single_header_integer
 
-    subroutine df_change_single_header_logical(this,header,j,val)
+    subroutine df_change_single_header_logical(this,header,row_index,val)
         class(data_frame),intent(inout) :: this
         character(len=*),intent(in) :: header
-        integer,intent(in) :: j
+        integer,intent(in) :: row_index
         logical,intent(in) :: val
         
         integer :: ind, data_index
@@ -2044,14 +2044,14 @@ contains
 
         if (this%type_loc(ind,1) /= LOGICAL_NUM) error stop 'column is not of logical type'
         data_index = this%type_loc(ind,2)
-        this%ldata(j,data_index) = val
+        this%ldata(row_index,data_index) = val
 
     end subroutine df_change_single_header_logical
 
-    subroutine df_change_single_header_character(this,header,j,val)
+    subroutine df_change_single_header_character(this,header,row_index,val)
         class(data_frame),intent(inout) :: this
         character(len=*),intent(in) :: header
-        integer,intent(in) :: j
+        integer,intent(in) :: row_index
         character(len=*),intent(in) :: val
         
         integer :: ind, data_index
@@ -2066,14 +2066,14 @@ contains
 
         if (this%type_loc(ind,1) /= CHARACTER_NUM) error stop 'column is not of character type'
         data_index = this%type_loc(ind,2)
-        this%chdata(j,data_index) = val
+        this%chdata(row_index,data_index) = val
 
     end subroutine df_change_single_header_character
 
-    subroutine df_change_single_header_complex(this,header,j,val)
+    subroutine df_change_single_header_complex(this,header,row_index,val)
         class(data_frame),intent(inout) :: this
         character(len=*),intent(in) :: header
-        integer,intent(in) :: j
+        integer,intent(in) :: row_index
         complex(rk),intent(in) :: val
         
         integer :: ind, data_index
@@ -2088,16 +2088,16 @@ contains
 
         if (this%type_loc(ind,1) /= COMPLEX_NUM) error stop 'column is not of complex type'
         data_index = this%type_loc(ind,2)
-        this%cdata(j,data_index) = val
+        this%cdata(row_index,data_index) = val
 
     end subroutine df_change_single_header_complex
 
 
 ! ~~~~ Change col of data frame with index
 
-    subroutine df_change_col_index_real(this,i,col)
+    subroutine df_change_col_index_real(this,col_index,col)
         class(data_frame),intent(inout) :: this
-        integer,intent(in) :: i
+        integer,intent(in) :: col_index
         real(rk),dimension(:),intent(in) :: col
 
         integer :: data_ind, col_len
@@ -2108,18 +2108,18 @@ contains
             error stop 'Different size columns in add col to data_frame'
         end if
 
-        if (this%type_loc(i,1) /= REAL_NUM) error stop 'column is not of real type'
-        data_ind = this%type_loc(i,2)
+        if (this%type_loc(col_index,1) /= REAL_NUM) error stop 'column is not of real type'
+        data_ind = this%type_loc(col_index,2)
 
         if ((.not. this%enforce_length) .and. col_len > this%rrows_max) call this%stretch_cols_real(col_len)
         this%rdata(:col_len,data_ind) = col
-        if (.not. this%enforce_length) this%col_lens(i) = col_len
+        if (.not. this%enforce_length) this%col_lens(col_index) = col_len
 
     end subroutine df_change_col_index_real
 
-    subroutine df_change_col_index_integer(this,i,col)
+    subroutine df_change_col_index_integer(this,col_index,col)
         class(data_frame),intent(inout) :: this
-        integer,intent(in) :: i
+        integer,intent(in) :: col_index
         integer(ik),dimension(:),intent(in) :: col
 
         integer :: data_ind, col_len
@@ -2130,18 +2130,18 @@ contains
             error stop 'Different size columns in add col to data_frame'
         end if
 
-        if (this%type_loc(i,1) /= INTEGER_NUM) error stop 'column is not of integer type'
-        data_ind = this%type_loc(i,2)
+        if (this%type_loc(col_index,1) /= INTEGER_NUM) error stop 'column is not of integer type'
+        data_ind = this%type_loc(col_index,2)
 
         if ((.not. this%enforce_length) .and. col_len > this%irows_max) call this%stretch_cols_integer(col_len)
         this%idata(:col_len,data_ind) = col
-        if (.not. this%enforce_length) this%col_lens(i) = col_len
+        if (.not. this%enforce_length) this%col_lens(col_index) = col_len
 
     end subroutine df_change_col_index_integer
 
-    subroutine df_change_col_index_logical(this,i,col)
+    subroutine df_change_col_index_logical(this,col_index,col)
         class(data_frame),intent(inout) :: this
-        integer,intent(in) :: i
+        integer,intent(in) :: col_index
         logical,dimension(:),intent(in) :: col
 
         integer :: data_ind, col_len
@@ -2152,18 +2152,18 @@ contains
             error stop 'Different size columns in add col to data_frame'
         end if
 
-        if (this%type_loc(i,1) /= LOGICAL_NUM) error stop 'column is not of logical type'
-        data_ind = this%type_loc(i,2)
+        if (this%type_loc(col_index,1) /= LOGICAL_NUM) error stop 'column is not of logical type'
+        data_ind = this%type_loc(col_index,2)
 
         if ((.not. this%enforce_length) .and. col_len > this%lrows_max) call this%stretch_cols_logical(col_len)
         this%ldata(:col_len,data_ind) = col
-        if (.not. this%enforce_length) this%col_lens(i) = col_len
+        if (.not. this%enforce_length) this%col_lens(col_index) = col_len
 
     end subroutine df_change_col_index_logical
 
-    subroutine df_change_col_index_character(this,i,col)
+    subroutine df_change_col_index_character(this,col_index,col)
         class(data_frame),intent(inout) :: this
-        integer,intent(in) :: i
+        integer,intent(in) :: col_index
         character(len=*),dimension(:),intent(in) :: col
 
         integer :: data_ind, col_len
@@ -2174,18 +2174,18 @@ contains
             error stop 'Different size columns in add col to data_frame'
         end if
 
-        if (this%type_loc(i,1) /= CHARACTER_NUM) error stop 'column is not of character type'
-        data_ind = this%type_loc(i,2)
+        if (this%type_loc(col_index,1) /= CHARACTER_NUM) error stop 'column is not of character type'
+        data_ind = this%type_loc(col_index,2)
 
         if ((.not. this%enforce_length) .and. col_len > this%chrows_max) call this%stretch_cols_character(col_len)
         this%chdata(:col_len,data_ind) = col
-        if (.not. this%enforce_length) this%col_lens(i) = col_len
+        if (.not. this%enforce_length) this%col_lens(col_index) = col_len
 
     end subroutine df_change_col_index_character
 
-    subroutine df_change_col_index_complex(this,i,col)
+    subroutine df_change_col_index_complex(this,col_index,col)
         class(data_frame),intent(inout) :: this
-        integer,intent(in) :: i
+        integer,intent(in) :: col_index
         complex(rk),dimension(:),intent(in) :: col
 
         integer :: data_ind, col_len
@@ -2196,12 +2196,12 @@ contains
             error stop 'Different size columns in add col to data_frame'
         end if
 
-        if (this%type_loc(i,1) /= COMPLEX_NUM) error stop 'column is not of complex type'
-        data_ind = this%type_loc(i,2)
+        if (this%type_loc(col_index,1) /= COMPLEX_NUM) error stop 'column is not of complex type'
+        data_ind = this%type_loc(col_index,2)
 
         if ((.not. this%enforce_length) .and. col_len > this%crows_max) call this%stretch_cols_complex(col_len)
         this%cdata(:col_len,data_ind) = col
-        if (.not. this%enforce_length) this%col_lens(i) = col_len
+        if (.not. this%enforce_length) this%col_lens(col_index) = col_len
 
     end subroutine df_change_col_index_complex
 

--- a/src/df_fortranDF.f90
+++ b/src/df_fortranDF.f90
@@ -20,7 +20,7 @@ module df_fortranDF
     type :: data_frame
         private
         
-        integer :: n, max_char_len
+        integer :: num_cols, max_char_len
         logical :: with_headers, enforce_length
         character(len=:),dimension(:),allocatable :: headers
 
@@ -199,7 +199,7 @@ contains
             this%enforce_length = .true.
         end if
 
-        this%n = 0
+        this%num_cols = 0
         this%rcols = -1
         this%icols = -1
         this%lcols = -1
@@ -231,7 +231,7 @@ contains
 
         if (allocated(this%headers)) deallocate(this%headers)
 
-        this%n = 0
+        this%num_cols = 0
         this%rcols = -1
         this%icols = -1
         this%lcols = -1
@@ -257,7 +257,7 @@ contains
         class(data_frame),intent(in) :: this
         integer :: n
 
-        n = this%n
+        n = this%num_cols
 
     end function df_get_num_cols
 
@@ -385,10 +385,10 @@ contains
 
         integer,dimension(:,:),allocatable :: type_loc_tmp
 
-        if (this%n > 0) then
-            allocate(type_loc_tmp(this%n+1,2))
-            type_loc_tmp(1:this%n,:) = this%type_loc
-            type_loc_tmp(this%n+1,:) = [dtype,loc]
+        if (this%num_cols > 0) then
+            allocate(type_loc_tmp(this%num_cols+1,2))
+            type_loc_tmp(1:this%num_cols,:) = this%type_loc
+            type_loc_tmp(this%num_cols+1,:) = [dtype,loc]
             this%type_loc = type_loc_tmp
         else
             allocate(this%type_loc(1,2))
@@ -441,7 +441,7 @@ contains
 
         end = size(col,dim=1)
 
-        n = this%n
+        n = this%num_cols
         rcols = this%rcols
         if (n > 0) then
             if (rcols > 0) then
@@ -457,10 +457,10 @@ contains
                 this%rcols = 1
                 call this%add_type_loc(REAL_NUM,1)
             end if
-            this%n = n + 1
+            this%num_cols = n + 1
         else
             call this%add_type_loc(REAL_NUM,1)
-            this%n = 1
+            this%num_cols = 1
             this%rcols = 1
             allocate(this%rdata(this%rrows_max,1))
             this%rdata(:end,1) = col
@@ -481,7 +481,7 @@ contains
 
         end = size(col,dim=1)
 
-        n = this%n
+        n = this%num_cols
         icols = this%icols
         if (n > 0) then
             if (icols > 0) then
@@ -497,10 +497,10 @@ contains
                 this%icols = 1
                 call this%add_type_loc(INTEGER_NUM,1)
             end if
-            this%n = n + 1
+            this%num_cols = n + 1
         else
             call this%add_type_loc(INTEGER_NUM,1)
-            this%n = 1
+            this%num_cols = 1
             this%icols = 1
             allocate(this%idata(this%irows_max,1))
             this%idata(:,1) = col
@@ -521,7 +521,7 @@ contains
 
         end = size(col,dim=1)
 
-        n = this%n
+        n = this%num_cols
         lcols = this%lcols
         if (n > 0) then
             if (lcols > 0) then
@@ -537,10 +537,10 @@ contains
                 this%lcols = 1
                 call this%add_type_loc(LOGICAL_NUM,1)
             end if
-            this%n = n + 1
+            this%num_cols = n + 1
         else
             call this%add_type_loc(LOGICAL_NUM,1)
-            this%n = 1
+            this%num_cols = 1
             this%lcols = 1
             allocate(this%ldata(this%lrows_max,1))
             this%ldata(:,1) = col
@@ -561,7 +561,7 @@ contains
 
         end = size(col,dim=1)
 
-        n = this%n
+        n = this%num_cols
         chcols = this%chcols
         if (n > 0) then
             if (chcols > 0) then
@@ -577,10 +577,10 @@ contains
                 this%chcols = 1
                 call this%add_type_loc(CHARACTER_NUM,1)
             end if
-            this%n = n + 1
+            this%num_cols = n + 1
         else
             call this%add_type_loc(CHARACTER_NUM,1)
-            this%n = 1
+            this%num_cols = 1
             this%chcols = 1
             allocate(character(this%max_char_len) :: this%chdata(this%chrows_max,1))
             this%chdata(:,1) = col
@@ -601,7 +601,7 @@ contains
 
         end = size(col,dim=1)
 
-        n = this%n
+        n = this%num_cols
         ccols = this%ccols
         if (n > 0) then
             if (ccols > 0) then
@@ -616,10 +616,10 @@ contains
                 this%ccols = 1
                 call this%add_type_loc(COMPLEX_NUM,1)
             end if
-            this%n = n + 1
+            this%num_cols = n + 1
         else
             call this%add_type_loc(COMPLEX_NUM,1)
-            this%n = 1
+            this%num_cols = 1
             this%ccols = 1
             allocate(this%cdata(this%crows_max,1))
             this%cdata(:,1) = col
@@ -676,7 +676,7 @@ contains
                 this%nrows_max = col_len
         end if
 
-        if (this%n < 1) then
+        if (this%num_cols < 1) then
             this%with_headers = .false.
             if (present(header)) this%with_headers = .true.
         end if
@@ -724,7 +724,7 @@ contains
                 this%nrows_max = col_len
         end if
 
-        if (this%n < 1) then
+        if (this%num_cols < 1) then
             this%with_headers = .false.
             if (present(header)) this%with_headers = .true.
         end if
@@ -772,7 +772,7 @@ contains
                 this%nrows_max = col_len
         end if
 
-        if (this%n < 1) then
+        if (this%num_cols < 1) then
             this%with_headers = .false.
             if (present(header)) this%with_headers = .true.
         end if
@@ -820,7 +820,7 @@ contains
                 this%nrows_max = col_len
         end if
 
-        if (this%n < 1) then
+        if (this%num_cols < 1) then
             this%with_headers = .false.
             if (present(header)) this%with_headers = .true.
         end if
@@ -868,7 +868,7 @@ contains
                 this%nrows_max = col_len
         end if
 
-        if (this%n < 1) then
+        if (this%num_cols < 1) then
             this%with_headers = .false.
             if (present(header)) this%with_headers = .true.
         end if
@@ -1001,7 +1001,7 @@ contains
         
         if (this%rrows_max < 0) this%rrows_max = col_size
 
-        n = this%n
+        n = this%num_cols
         rcols = this%rcols
         if (n > 0) then
             if (rcols > 0) then
@@ -1015,10 +1015,10 @@ contains
                 this%rcols = 1
                 call this%add_type_loc(REAL_NUM,1)
             end if
-            this%n = n + 1
+            this%num_cols = n + 1
         else
             call this%add_type_loc(REAL_NUM,1)
-            this%n = 1
+            this%num_cols = 1
             this%rcols = 1
             allocate(this%rdata(this%rrows_max,1))
         end if
@@ -1037,7 +1037,7 @@ contains
         
         if (this%irows_max < 0) this%irows_max = col_size
 
-        n = this%n
+        n = this%num_cols
         icols = this%icols
         if (n > 0) then
             if (icols > 0) then
@@ -1051,10 +1051,10 @@ contains
                 this%icols = 1
                 call this%add_type_loc(INTEGER_NUM,1)
             end if
-            this%n = n + 1
+            this%num_cols = n + 1
         else
             call this%add_type_loc(INTEGER_NUM,1)
-            this%n = 1
+            this%num_cols = 1
             this%icols = 1
             allocate(this%idata(this%irows_max,1))
         end if
@@ -1073,7 +1073,7 @@ contains
         
         if (this%lrows_max < 0) this%lrows_max = col_size
 
-        n = this%n
+        n = this%num_cols
         lcols = this%lcols
         if (n > 0) then
             if (lcols > 0) then
@@ -1087,10 +1087,10 @@ contains
                 this%lcols = 1
                 call this%add_type_loc(LOGICAL_NUM,1)
             end if
-            this%n = n + 1
+            this%num_cols = n + 1
         else
             call this%add_type_loc(LOGICAL_NUM,1)
-            this%n = 1
+            this%num_cols = 1
             this%lcols = 1
             allocate(this%ldata(this%lrows_max,1))
         end if
@@ -1109,7 +1109,7 @@ contains
         
         if (this%chrows_max < 0) this%chrows_max = col_size
 
-        n = this%n
+        n = this%num_cols
         chcols = this%chcols
         if (n > 0) then
             if (chcols > 0) then
@@ -1123,10 +1123,10 @@ contains
                 this%chcols = 1
                 call this%add_type_loc(CHARACTER_NUM,1)
             end if
-            this%n = n + 1
+            this%num_cols = n + 1
         else
             call this%add_type_loc(CHARACTER_NUM,1)
-            this%n = 1
+            this%num_cols = 1
             this%chcols = 1
             allocate(character(this%max_char_len) :: this%chdata(this%chrows_max,1))
         end if
@@ -1145,7 +1145,7 @@ contains
         
         if (this%crows_max < 0) this%crows_max = col_size
 
-        n = this%n
+        n = this%num_cols
         ccols = this%ccols
         if (n > 0) then
             if (ccols > 0) then
@@ -1159,10 +1159,10 @@ contains
                 this%ccols = 1
                 call this%add_type_loc(COMPLEX_NUM,1)
             end if
-            this%n = n + 1
+            this%num_cols = n + 1
         else
             call this%add_type_loc(COMPLEX_NUM,1)
-            this%n = 1
+            this%num_cols = 1
             this%ccols = 1
             allocate(this%cdata(this%crows_max,1))
         end if
@@ -1185,7 +1185,7 @@ contains
                 this%nrows_max = col_size
         end if
 
-        if (this%n < 1) then
+        if (this%num_cols < 1) then
             this%with_headers = .false.
             if (present(header)) this%with_headers = .true.
         end if
@@ -1230,7 +1230,7 @@ contains
                 this%nrows_max = col_size
         end if
 
-        if (this%n < 1) then
+        if (this%num_cols < 1) then
             this%with_headers = .false.
             if (present(header)) this%with_headers = .true.
         end if
@@ -1275,7 +1275,7 @@ contains
                 this%nrows_max = col_size
         end if
 
-        if (this%n < 1) then
+        if (this%num_cols < 1) then
             this%with_headers = .false.
             if (present(header)) this%with_headers = .true.
         end if
@@ -1320,7 +1320,7 @@ contains
                 this%nrows_max = col_size
         end if
 
-        if (this%n < 1) then
+        if (this%num_cols < 1) then
             this%with_headers = .false.
             if (present(header)) this%with_headers = .true.
         end if
@@ -1365,7 +1365,7 @@ contains
                 this%nrows_max = col_size
         end if
 
-        if (this%n < 1) then
+        if (this%num_cols < 1) then
             this%with_headers = .false.
             if (present(header)) this%with_headers = .true.
         end if
@@ -2408,7 +2408,7 @@ contains
         cfmt = "2"//trim(adjustl(rfmt))
 
 
-        num_cols = this%n
+        num_cols = this%num_cols
         len_cols = this%nrows_max
         
         call write_horiz()


### PR DESCRIPTION
Modified variable names `i` and `j` in `df%set*` subroutines to `col_index` or `row_index` depending on the context. This is much less confusing when either modifying the procedures or even looking at the call signatures. Variables in `df_write_unformatted` and `df_read_unformatted` have been left alone as these procedures need full revamping anyways.

Fixes issue https://github.com/jaiken17/fortranDF/issues/15.

Also changed `n`, class variable, to `num_cols` to be more descriptive.