### PR TITLE
Get arrays

### DIFF
--- a/app/main.f90
+++ b/app/main.f90
@@ -18,18 +18,27 @@ program main
 
     print*, " " ! newline
 
-    print*, "get column 'value': ", df%getr("value")
+    print*, "get column 'value':             ", df%getr("value")
+    print*, "get column 'value' from 2 to 3: ", df%getr("value",2,3)
     print*, "get column 1: ", df%geti(1)
     print*, "num real cols:    ", df%nreal_cols()
-    print*, "num integer cols: ", df%nreal_cols()
+    print*, "num integer cols: ", df%ninteger_cols()
     print*, "header of column 2: ", df%header(2)
     block 
         integer :: i
         real(rk),allocatable :: data(:,:)
 
+        print*, "cols of 'value', 'value2', 'value':"
         data = df%getr([" value","value2"," value"])
         do i=1,size(data,dim=1)
             print*, data(i,1), data(i,2), data(i,3)
+        end do
+        print*, " "
+
+        print*, "rows 2 to 4 of 'value', 'value2'"
+        data = df%getr([" value","value2"],2,4)
+        do i=1,size(data,dim=1)
+            print*, data(i,1), data(i,2)
         end do
 
     end block

--- a/app/main.f90
+++ b/app/main.f90
@@ -10,6 +10,7 @@ program main
     call df%new()
     call df%append([1,2,3,4],"index")
     call df%append([3.0_rk, 2.0_rk, 7.d-6, 5.0_rk],"value")
+    call df%append([1.0_rk,2.0_rk,3.0_rk,4.0_rk],"value2")
     call df%append(["hello","world","test1","test2"], "chars")
     call df%append([.true.,.true.,.false.,.true.],"truth")
 
@@ -22,6 +23,16 @@ program main
     print*, "num real cols:    ", df%nreal_cols()
     print*, "num integer cols: ", df%nreal_cols()
     print*, "header of column 2: ", df%header(2)
+    block 
+        integer :: i
+        real(rk),allocatable :: data(:,:)
+
+        data = df%getr([" value","value2"," value"])
+        do i=1,size(data,dim=1)
+            print*, data(i,1), data(i,2), data(i,3)
+        end do
+
+    end block
 
     call df%destroy()
 

--- a/src/df_fortranDF.f90
+++ b/src/df_fortranDF.f90
@@ -129,22 +129,27 @@ module df_fortranDF
                      df_get_col_header_logical,     &
                      df_get_col_header_character,   &
                      df_get_col_header_complex
+        procedure :: df_get_mult_col_header_real,       &
+                     df_get_mult_col_header_integer,    &
+                     df_get_mult_col_header_logical,    &
+                     df_get_mult_col_header_character,  &
+                     df_get_mult_col_header_complex
 
         generic,public :: getr => df_get_val_real, df_get_val_header_real,              &
                                   df_get_col_ind_real, df_get_col_header_real,          &
-                                  df_get_mult_col_ind_real
+                                  df_get_mult_col_ind_real,df_get_mult_col_header_real
         generic,public :: geti => df_get_val_integer, df_get_val_header_integer,        &
                                   df_get_col_ind_integer, df_get_col_header_integer,    &
-                                  df_get_mult_col_ind_integer
+                                  df_get_mult_col_ind_integer,df_get_mult_col_header_integer
         generic,public :: getl => df_get_val_logical, df_get_val_header_logical,        &
                                   df_get_col_ind_logical, df_get_col_header_logical,    &
-                                  df_get_mult_col_ind_logical
+                                  df_get_mult_col_ind_logical,df_get_mult_col_header_logical
         generic,public :: getch => df_get_val_character, df_get_val_header_character,       &
                                    df_get_col_ind_character, df_get_col_header_character,   &
-                                   df_get_mult_col_ind_character
+                                   df_get_mult_col_ind_character,df_get_mult_col_header_character
         generic,public :: getc => df_get_val_complex, df_get_val_header_complex,        &
                                   df_get_col_ind_complex, df_get_col_header_complex,    &
-                                  df_get_mult_col_ind_complex
+                                  df_get_mult_col_ind_complex,df_get_mult_col_header_complex
 
         procedure :: df_change_single_indices_real,         &
                      df_change_single_indices_integer,      &
@@ -1711,7 +1716,6 @@ contains
 
     end function df_get_mult_col_ind_complex
 
-
     
 ! ~~~~ Get Column DF from header
 
@@ -1881,6 +1885,182 @@ contains
         col = this%cdata(:end,data_index)
 
     end function df_get_col_header_complex
+
+
+! ~~~~ Get multiple cols header
+
+    pure function df_get_mult_col_header_real(this,headers,full) result(cols)
+        class(data_frame),intent(in) :: this
+        character(len=*),intent(in) :: headers(:)
+        logical,intent(in),optional :: full ! return full column
+        real(rk),dimension(:,:),allocatable :: cols
+
+        integer :: max_len, i
+        integer,allocatable :: col_indices(:), data_indices(:)
+
+        if (.not. this%with_headers) error stop "data frame has no headers to look up"
+
+        allocate(col_indices(size(headers,dim=1)))
+        do i=1,size(headers,dim=1)
+            col_indices(i) = findloc(this%headers,trim(adjustl(headers(i))),dim=1)
+            if (col_indices(i) < 1) error stop 'header not present in data frame'
+            if (this%type_loc(col_indices(i),1) /= REAL_NUM) error stop 'column is not of real type'
+        end do
+
+        data_indices = this%type_loc(col_indices,2)
+
+        if (.not. this%enforce_length) then
+            max_len = maxval(this%col_lens(col_indices))
+        else
+            max_len = this%nrows_max
+        end if
+
+        if (present(full)) then
+            if (full) max_len = this%rrows_max
+        end if
+
+        cols = this%rdata(:max_len,data_indices)
+
+    end function df_get_mult_col_header_real
+
+    pure function df_get_mult_col_header_integer(this,headers,full) result(cols)
+        class(data_frame),intent(in) :: this
+        character(len=*),intent(in) :: headers(:)
+        logical,intent(in),optional :: full ! return full column
+        integer(ik),dimension(:,:),allocatable :: cols
+
+        integer :: max_len, i
+        integer,allocatable :: col_indices(:), data_indices(:)
+
+        if (.not. this%with_headers) error stop "data frame has no headers to look up"
+
+        allocate(col_indices(size(headers,dim=1)))
+        do i=1,size(headers,dim=1)
+            col_indices(i) = findloc(this%headers,trim(adjustl(headers(i))),dim=1)
+            if (col_indices(i) < 1) error stop 'header not present in data frame'
+            if (this%type_loc(col_indices(i),1) /= INTEGER_NUM) error stop 'column is not of integer type'
+        end do
+
+        data_indices = this%type_loc(col_indices,2)
+
+        if (.not. this%enforce_length) then
+            max_len = maxval(this%col_lens(col_indices))
+        else
+            max_len = this%nrows_max
+        end if
+
+        if (present(full)) then
+            if (full) max_len = this%irows_max
+        end if
+
+        cols = this%idata(:max_len,data_indices)
+
+    end function df_get_mult_col_header_integer
+
+
+    pure function df_get_mult_col_header_logical(this,headers,full) result(cols)
+        class(data_frame),intent(in) :: this
+        character(len=*),intent(in) :: headers(:)
+        logical,intent(in),optional :: full ! return full column
+        logical,dimension(:,:),allocatable :: cols
+
+        integer :: max_len, i
+        integer,allocatable :: col_indices(:), data_indices(:)
+
+        if (.not. this%with_headers) error stop "data frame has no headers to look up"
+
+        allocate(col_indices(size(headers,dim=1)))
+        do i=1,size(headers,dim=1)
+            col_indices(i) = findloc(this%headers,trim(adjustl(headers(i))),dim=1)
+            if (col_indices(i) < 1) error stop 'header not present in data frame'
+            if (this%type_loc(col_indices(i),1) /= LOGICAL_NUM) error stop 'column is not of logical type'
+        end do
+
+        data_indices = this%type_loc(col_indices,2)
+
+        if (.not. this%enforce_length) then
+            max_len = maxval(this%col_lens(col_indices))
+        else
+            max_len = this%nrows_max
+        end if
+
+        if (present(full)) then
+            if (full) max_len = this%lrows_max
+        end if
+
+        cols = this%ldata(:max_len,data_indices)
+
+    end function df_get_mult_col_header_logical
+
+
+    pure function df_get_mult_col_header_character(this,headers,full) result(cols)
+        class(data_frame),intent(in) :: this
+        character(len=*),intent(in) :: headers(:)
+        logical,intent(in),optional :: full ! return full column
+        character(:),dimension(:,:),allocatable :: cols
+
+        integer :: max_len, i
+        integer,allocatable :: col_indices(:), data_indices(:)
+
+        if (.not. this%with_headers) error stop "data frame has no headers to look up"
+
+        allocate(col_indices(size(headers,dim=1)))
+        do i=1,size(headers,dim=1)
+            col_indices(i) = findloc(this%headers,trim(adjustl(headers(i))),dim=1)
+            if (col_indices(i) < 1) error stop 'header not present in data frame'
+            if (this%type_loc(col_indices(i),1) /= CHARACTER_NUM) error stop 'column is not of character type'
+        end do
+
+        data_indices = this%type_loc(col_indices,2)
+
+        if (.not. this%enforce_length) then
+            max_len = maxval(this%col_lens(col_indices))
+        else
+            max_len = this%nrows_max
+        end if
+
+        if (present(full)) then
+            if (full) max_len = this%chrows_max
+        end if
+
+        cols = this%chdata(:max_len,data_indices)
+
+    end function df_get_mult_col_header_character
+
+
+    pure function df_get_mult_col_header_complex(this,headers,full) result(cols)
+        class(data_frame),intent(in) :: this
+        character(len=*),intent(in) :: headers(:)
+        logical,intent(in),optional :: full ! return full column
+        complex(rk),dimension(:,:),allocatable :: cols
+
+        integer :: max_len, i
+        integer,allocatable :: col_indices(:), data_indices(:)
+
+        if (.not. this%with_headers) error stop "data frame has no headers to look up"
+
+        allocate(col_indices(size(headers,dim=1)))
+        do i=1,size(headers,dim=1)
+            col_indices(i) = findloc(this%headers,trim(adjustl(headers(i))),dim=1)
+            if (col_indices(i) < 1) error stop 'header not present in data frame'
+            if (this%type_loc(col_indices(i),1) /= COMPLEX_NUM) error stop 'column is not of complex type'
+        end do
+
+        data_indices = this%type_loc(col_indices,2)
+
+        if (.not. this%enforce_length) then
+            max_len = maxval(this%col_lens(col_indices))
+        else
+            max_len = this%nrows_max
+        end if
+
+        if (present(full)) then
+            if (full) max_len = this%crows_max
+        end if
+
+        cols = this%cdata(:max_len,data_indices)
+
+    end function df_get_mult_col_header_complex
 
 
 ! ~~~~ Get Single Val DF

--- a/src/df_fortranDF.f90
+++ b/src/df_fortranDF.f90
@@ -135,21 +135,56 @@ module df_fortranDF
                      df_get_mult_col_header_character,  &
                      df_get_mult_col_header_complex
 
+        procedure :: df_get_partial_col_ind_real,       &
+                     df_get_partial_col_ind_integer,    &
+                     df_get_partial_col_ind_logical,    &
+                     df_get_partial_col_ind_character,  &
+                     df_get_partial_col_ind_complex
+        procedure :: df_get_mult_partial_col_ind_real,      &
+                     df_get_mult_partial_col_ind_integer,   &
+                     df_get_mult_partial_col_ind_logical,   &
+                     df_get_mult_partial_col_ind_character, &
+                     df_get_mult_partial_col_ind_complex
+        procedure :: df_get_partial_col_header_real,        &
+                     df_get_partial_col_header_integer,     &
+                     df_get_partial_col_header_logical,     &
+                     df_get_partial_col_header_character,   &
+                     df_get_partial_col_header_complex
+        procedure :: df_get_mult_partial_col_header_real,       &
+                     df_get_mult_partial_col_header_integer,    &
+                     df_get_mult_partial_col_header_logical,    &
+                     df_get_mult_partial_col_header_character,  &
+                     df_get_mult_partial_col_header_complex
+
         generic,public :: getr => df_get_val_real, df_get_val_header_real,              &
                                   df_get_col_ind_real, df_get_col_header_real,          &
-                                  df_get_mult_col_ind_real,df_get_mult_col_header_real
+                                  df_get_mult_col_ind_real,df_get_mult_col_header_real, &
+                                  df_get_partial_col_ind_real,df_get_partial_col_header_real,   &
+                                  df_get_mult_partial_col_ind_real,df_get_mult_partial_col_header_real
+
         generic,public :: geti => df_get_val_integer, df_get_val_header_integer,        &
                                   df_get_col_ind_integer, df_get_col_header_integer,    &
-                                  df_get_mult_col_ind_integer,df_get_mult_col_header_integer
+                                  df_get_mult_col_ind_integer,df_get_mult_col_header_integer, &
+                                  df_get_partial_col_ind_integer,df_get_partial_col_header_integer,   &
+                                  df_get_mult_partial_col_ind_integer,df_get_mult_partial_col_header_integer
+
         generic,public :: getl => df_get_val_logical, df_get_val_header_logical,        &
                                   df_get_col_ind_logical, df_get_col_header_logical,    &
-                                  df_get_mult_col_ind_logical,df_get_mult_col_header_logical
+                                  df_get_mult_col_ind_logical,df_get_mult_col_header_logical, &
+                                  df_get_partial_col_ind_logical,df_get_partial_col_header_logical,   &
+                                  df_get_mult_partial_col_ind_logical,df_get_mult_partial_col_header_logical
+
         generic,public :: getch => df_get_val_character, df_get_val_header_character,       &
                                    df_get_col_ind_character, df_get_col_header_character,   &
-                                   df_get_mult_col_ind_character,df_get_mult_col_header_character
+                                   df_get_mult_col_ind_character,df_get_mult_col_header_character, &
+                                   df_get_partial_col_ind_character,df_get_partial_col_header_character,   &
+                                   df_get_mult_partial_col_ind_character,df_get_mult_partial_col_header_character
+
         generic,public :: getc => df_get_val_complex, df_get_val_header_complex,        &
                                   df_get_col_ind_complex, df_get_col_header_complex,    &
-                                  df_get_mult_col_ind_complex,df_get_mult_col_header_complex
+                                  df_get_mult_col_ind_complex,df_get_mult_col_header_complex, &
+                                  df_get_partial_col_ind_complex,df_get_partial_col_header_complex,   &
+                                  df_get_mult_partial_col_ind_complex,df_get_mult_partial_col_header_complex
 
         procedure :: df_change_single_indices_real,         &
                      df_change_single_indices_integer,      &
@@ -2248,6 +2283,635 @@ contains
         val = this%cdata(row_index,data_index)
 
     end function df_get_val_header_complex
+
+
+! ~~~~ Get partial column index
+
+    pure function df_get_partial_col_ind_real(this,col_index,start,end) result(vals)
+        class(data_frame),intent(in) :: this
+        integer,intent(in) :: col_index, start, end
+        real(rk),dimension(:),allocatable :: vals
+
+        integer :: data_index, max_end, min_start
+
+        if (this%type_loc(col_index,1) /= REAL_NUM) error stop 'column is not of real type'
+        data_index = this%type_loc(col_index,2)
+
+        min_start = 1   ! 1 indexed
+        if (.not. this%enforce_length) then
+            max_end = this%col_lens(col_index)
+        else
+            max_end = this%nrows_max
+        end if
+        
+        ! MAYBE JUST USE IMPLICIT ARRAY ERRORS
+        ! if (end>max_end) error stop 'end outside of column range'
+        ! if (start<min_start) error stop 'start outside of column range'
+        ! if (start>end) error stop 'start must be smaller than end'
+
+        vals = this%rdata(start:end,data_index)
+
+    end function df_get_partial_col_ind_real
+
+    pure function df_get_partial_col_ind_integer(this,col_index,start,end) result(vals)
+        class(data_frame),intent(in) :: this
+        integer,intent(in) :: col_index, start, end
+        integer(ik),dimension(:),allocatable :: vals
+
+        integer :: data_index, max_end, min_start
+
+        if (this%type_loc(col_index,1) /= INTEGER_NUM) error stop 'column is not of integer type'
+        data_index = this%type_loc(col_index,2)
+
+        min_start = 1   ! 1 indexed
+        if (.not. this%enforce_length) then
+            max_end = this%col_lens(col_index)
+        else
+            max_end = this%nrows_max
+        end if
+        
+        ! MAYBE JUST USE IMPLICIT ARRAY ERRORS
+        ! if (end>max_end) error stop 'end outside of column range'
+        ! if (start<min_start) error stop 'start outside of column range'
+        ! if (start>end) error stop 'start must be smaller than end'
+
+        vals = this%idata(start:end,data_index)
+
+    end function df_get_partial_col_ind_integer
+
+
+    pure function df_get_partial_col_ind_logical(this,col_index,start,end) result(vals)
+        class(data_frame),intent(in) :: this
+        integer,intent(in) :: col_index, start, end
+        logical,dimension(:),allocatable :: vals
+
+        integer :: data_index, max_end, min_start
+
+        if (this%type_loc(col_index,1) /= LOGICAL_NUM) error stop 'column is not of logical type'
+        data_index = this%type_loc(col_index,2)
+
+        min_start = 1   ! 1 indexed
+        if (.not. this%enforce_length) then
+            max_end = this%col_lens(col_index)
+        else
+            max_end = this%nrows_max
+        end if
+        
+        ! MAYBE JUST USE IMPLICIT ARRAY ERRORS
+        ! if (end>max_end) error stop 'end outside of column range'
+        ! if (start<min_start) error stop 'start outside of column range'
+        ! if (start>end) error stop 'start must be smaller than end'
+
+        vals = this%ldata(start:end,data_index)
+
+    end function df_get_partial_col_ind_logical
+
+
+    pure function df_get_partial_col_ind_character(this,col_index,start,end) result(vals)
+        class(data_frame),intent(in) :: this
+        integer,intent(in) :: col_index, start, end
+        character(:),dimension(:),allocatable :: vals
+
+        integer :: data_index, max_end, min_start
+
+        if (this%type_loc(col_index,1) /= CHARACTER_NUM) error stop 'column is not of character type'
+        data_index = this%type_loc(col_index,2)
+
+        min_start = 1   ! 1 indexed
+        if (.not. this%enforce_length) then
+            max_end = this%col_lens(col_index)
+        else
+            max_end = this%nrows_max
+        end if
+        
+        ! MAYBE JUST USE IMPLICIT ARRAY ERRORS
+        ! if (end>max_end) error stop 'end outside of column range'
+        ! if (start<min_start) error stop 'start outside of column range'
+        ! if (start>end) error stop 'start must be smaller than end'
+
+        vals = this%chdata(start:end,data_index)
+
+    end function df_get_partial_col_ind_character
+
+
+    pure function df_get_partial_col_ind_complex(this,col_index,start,end) result(vals)
+        class(data_frame),intent(in) :: this
+        integer,intent(in) :: col_index, start, end
+        complex(rk),dimension(:),allocatable :: vals
+
+        integer :: data_index, max_end, min_start
+
+        if (this%type_loc(col_index,1) /= COMPLEX_NUM) error stop 'column is not of complex type'
+        data_index = this%type_loc(col_index,2)
+
+        min_start = 1   ! 1 indexed
+        if (.not. this%enforce_length) then
+            max_end = this%col_lens(col_index)
+        else
+            max_end = this%nrows_max
+        end if
+        
+        ! MAYBE JUST USE IMPLICIT ARRAY ERRORS
+        ! if (end>max_end) error stop 'end outside of column range'
+        ! if (start<min_start) error stop 'start outside of column range'
+        ! if (start>end) error stop 'start must be smaller than end'
+
+        vals = this%cdata(start:end,data_index)
+
+    end function df_get_partial_col_ind_complex
+
+
+! ~~~~ Get multiple partial columns using indices
+
+    pure function df_get_mult_partial_col_ind_real(this,col_indices,start,end) result(vals)
+        class(data_frame),intent(in) :: this
+        integer,intent(in) :: col_indices(:), start, end
+        real(rk),dimension(:,:),allocatable :: vals
+
+        integer,allocatable :: data_indices(:)
+        integer :: i, max_end, min_start
+
+        do i=1,size(col_indices,dim=1)
+            if (this%type_loc(col_indices(i),1) /= REAL_NUM) error stop 'column is not of real type'
+        end do
+        data_indices = this%type_loc(col_indices,2)
+
+        min_start = 1   ! 1 indexed
+        if (.not. this%enforce_length) then
+            max_end = maxval(this%col_lens(col_indices))
+        else
+            max_end = this%nrows_max
+        end if
+        
+        ! MAYBE JUST USE IMPLICIT ARRAY ERRORS
+        ! if (end>max_end) error stop 'end outside of column range'
+        ! if (start<min_start) error stop 'start outside of column range'
+        ! if (start>end) error stop 'start must be smaller than end'
+
+        vals = this%rdata(start:end,data_indices)
+
+    end function df_get_mult_partial_col_ind_real
+    
+    pure function df_get_mult_partial_col_ind_integer(this,col_indices,start,end) result(vals)
+        class(data_frame),intent(in) :: this
+        integer,intent(in) :: col_indices(:), start, end
+        integer(ik),dimension(:,:),allocatable :: vals
+
+        integer,allocatable :: data_indices(:)
+        integer :: i, max_end, min_start
+
+        do i=1,size(col_indices,dim=1)
+            if (this%type_loc(col_indices(i),1) /= INTEGER_NUM) error stop 'column is not of integer type'
+        end do
+        data_indices = this%type_loc(col_indices,2)
+
+        min_start = 1   ! 1 indexed
+        if (.not. this%enforce_length) then
+            max_end = maxval(this%col_lens(col_indices))
+        else
+            max_end = this%nrows_max
+        end if
+        
+        ! MAYBE JUST USE IMPLICIT ARRAY ERRORS
+        ! if (end>max_end) error stop 'end outside of column range'
+        ! if (start<min_start) error stop 'start outside of column range'
+        ! if (start>end) error stop 'start must be smaller than end'
+
+        vals = this%idata(start:end,data_indices)
+
+    end function df_get_mult_partial_col_ind_integer
+    
+    pure function df_get_mult_partial_col_ind_logical(this,col_indices,start,end) result(vals)
+        class(data_frame),intent(in) :: this
+        integer,intent(in) :: col_indices(:), start, end
+        logical,dimension(:,:),allocatable :: vals
+
+        integer,allocatable :: data_indices(:)
+        integer :: i, max_end, min_start
+
+        do i=1,size(col_indices,dim=1)
+            if (this%type_loc(col_indices(i),1) /= LOGICAL_NUM) error stop 'column is not of logical type'
+        end do
+        data_indices = this%type_loc(col_indices,2)
+
+        min_start = 1   ! 1 indexed
+        if (.not. this%enforce_length) then
+            max_end = maxval(this%col_lens(col_indices))
+        else
+            max_end = this%nrows_max
+        end if
+        
+        ! MAYBE JUST USE IMPLICIT ARRAY ERRORS
+        ! if (end>max_end) error stop 'end outside of column range'
+        ! if (start<min_start) error stop 'start outside of column range'
+        ! if (start>end) error stop 'start must be smaller than end'
+
+        vals = this%ldata(start:end,data_indices)
+
+    end function df_get_mult_partial_col_ind_logical
+    
+    pure function df_get_mult_partial_col_ind_character(this,col_indices,start,end) result(vals)
+        class(data_frame),intent(in) :: this
+        integer,intent(in) :: col_indices(:), start, end
+        character(:),dimension(:,:),allocatable :: vals
+
+        integer,allocatable :: data_indices(:)
+        integer :: i, max_end, min_start
+
+        do i=1,size(col_indices,dim=1)
+            if (this%type_loc(col_indices(i),1) /= CHARACTER_NUM) error stop 'column is not of character type'
+        end do
+        data_indices = this%type_loc(col_indices,2)
+
+        min_start = 1   ! 1 indexed
+        if (.not. this%enforce_length) then
+            max_end = maxval(this%col_lens(col_indices))
+        else
+            max_end = this%nrows_max
+        end if
+        
+        ! MAYBE JUST USE IMPLICIT ARRAY ERRORS
+        ! if (end>max_end) error stop 'end outside of column range'
+        ! if (start<min_start) error stop 'start outside of column range'
+        ! if (start>end) error stop 'start must be smaller than end'
+
+        vals = this%chdata(start:end,data_indices)
+
+    end function df_get_mult_partial_col_ind_character
+    
+    pure function df_get_mult_partial_col_ind_complex(this,col_indices,start,end) result(vals)
+        class(data_frame),intent(in) :: this
+        integer,intent(in) :: col_indices(:), start, end
+        complex(rk),dimension(:,:),allocatable :: vals
+
+        integer,allocatable :: data_indices(:)
+        integer :: i, max_end, min_start
+
+        do i=1,size(col_indices,dim=1)
+            if (this%type_loc(col_indices(i),1) /= COMPLEX_NUM) error stop 'column is not of complex type'
+        end do
+        data_indices = this%type_loc(col_indices,2)
+
+        min_start = 1   ! 1 indexed
+        if (.not. this%enforce_length) then
+            max_end = maxval(this%col_lens(col_indices))
+        else
+            max_end = this%nrows_max
+        end if
+        
+        ! MAYBE JUST USE IMPLICIT ARRAY ERRORS
+        ! if (end>max_end) error stop 'end outside of column range'
+        ! if (start<min_start) error stop 'start outside of column range'
+        ! if (start>end) error stop 'start must be smaller than end'
+
+        vals = this%cdata(start:end,data_indices)
+
+    end function df_get_mult_partial_col_ind_complex
+
+
+! ~~~~ Get partial column header
+
+    pure function df_get_partial_col_header_real(this,header,start,end) result(vals)
+        class(data_frame),intent(in) :: this
+        character(*),intent(in) :: header
+        integer,intent(in) :: start, end
+        real(rk),dimension(:),allocatable :: vals
+
+        integer :: data_index, col_index, max_end, min_start
+
+        if (.not. this%with_headers) error stop "data frame has no headers to look up"
+
+        col_index = findloc(this%headers,trim(adjustl(header)),dim=1)
+        if (col_index < 1) error stop 'header not present in data frame'
+
+        if (this%type_loc(col_index,1) /= REAL_NUM) error stop 'column is not of real type'
+        data_index = this%type_loc(col_index,2)
+
+        min_start = 1   ! 1 indexed
+        if (.not. this%enforce_length) then
+            max_end = this%col_lens(col_index)
+        else
+            max_end = this%nrows_max
+        end if
+        
+        ! MAYBE JUST USE IMPLICIT ARRAY ERRORS
+        ! if (end>max_end) error stop 'end outside of column range'
+        ! if (start<min_start) error stop 'start outside of column range'
+        ! if (start>end) error stop 'start must be smaller than end'
+
+        vals = this%rdata(start:end,data_index)
+
+    end function df_get_partial_col_header_real
+
+    pure function df_get_partial_col_header_integer(this,header,start,end) result(vals)
+        class(data_frame),intent(in) :: this
+        character(*),intent(in) :: header
+        integer,intent(in) :: start, end
+        integer(ik),dimension(:),allocatable :: vals
+
+        integer :: data_index, col_index, max_end, min_start
+
+        if (.not. this%with_headers) error stop "data frame has no headers to look up"
+
+        col_index = findloc(this%headers,trim(adjustl(header)),dim=1)
+        if (col_index < 1) error stop 'header not present in data frame'
+
+        if (this%type_loc(col_index,1) /= INTEGER_NUM) error stop 'column is not of integer type'
+        data_index = this%type_loc(col_index,2)
+
+        min_start = 1   ! 1 indexed
+        if (.not. this%enforce_length) then
+            max_end = this%col_lens(col_index)
+        else
+            max_end = this%nrows_max
+        end if
+        
+        ! MAYBE JUST USE IMPLICIT ARRAY ERRORS
+        ! if (end>max_end) error stop 'end outside of column range'
+        ! if (start<min_start) error stop 'start outside of column range'
+        ! if (start>end) error stop 'start must be smaller than end'
+
+        vals = this%idata(start:end,data_index)
+
+    end function df_get_partial_col_header_integer
+
+    pure function df_get_partial_col_header_logical(this,header,start,end) result(vals)
+        class(data_frame),intent(in) :: this
+        character(*),intent(in) :: header
+        integer,intent(in) :: start, end
+        logical,dimension(:),allocatable :: vals
+
+        integer :: data_index, col_index, max_end, min_start
+
+        if (.not. this%with_headers) error stop "data frame has no headers to look up"
+
+        col_index = findloc(this%headers,trim(adjustl(header)),dim=1)
+        if (col_index < 1) error stop 'header not present in data frame'
+
+        if (this%type_loc(col_index,1) /= LOGICAL_NUM) error stop 'column is not of logical type'
+        data_index = this%type_loc(col_index,2)
+
+        min_start = 1   ! 1 indexed
+        if (.not. this%enforce_length) then
+            max_end = this%col_lens(col_index)
+        else
+            max_end = this%nrows_max
+        end if
+        
+        ! MAYBE JUST USE IMPLICIT ARRAY ERRORS
+        ! if (end>max_end) error stop 'end outside of column range'
+        ! if (start<min_start) error stop 'start outside of column range'
+        ! if (start>end) error stop 'start must be smaller than end'
+
+        vals = this%ldata(start:end,data_index)
+
+    end function df_get_partial_col_header_logical
+
+    pure function df_get_partial_col_header_character(this,header,start,end) result(vals)
+        class(data_frame),intent(in) :: this
+        character(*),intent(in) :: header
+        integer,intent(in) :: start, end
+        character(:),dimension(:),allocatable :: vals
+
+        integer :: data_index, col_index, max_end, min_start
+
+        if (.not. this%with_headers) error stop "data frame has no headers to look up"
+
+        col_index = findloc(this%headers,trim(adjustl(header)),dim=1)
+        if (col_index < 1) error stop 'header not present in data frame'
+
+        if (this%type_loc(col_index,1) /= CHARACTER_NUM) error stop 'column is not of character type'
+        data_index = this%type_loc(col_index,2)
+
+        min_start = 1   ! 1 indexed
+        if (.not. this%enforce_length) then
+            max_end = this%col_lens(col_index)
+        else
+            max_end = this%nrows_max
+        end if
+        
+        ! MAYBE JUST USE IMPLICIT ARRAY ERRORS
+        ! if (end>max_end) error stop 'end outside of column range'
+        ! if (start<min_start) error stop 'start outside of column range'
+        ! if (start>end) error stop 'start must be smaller than end'
+
+        vals = this%chdata(start:end,data_index)
+
+    end function df_get_partial_col_header_character
+
+    pure function df_get_partial_col_header_complex(this,header,start,end) result(vals)
+        class(data_frame),intent(in) :: this
+        character(*),intent(in) :: header
+        integer,intent(in) :: start, end
+        complex(rk),dimension(:),allocatable :: vals
+
+        integer :: data_index, col_index, max_end, min_start
+
+        if (.not. this%with_headers) error stop "data frame has no headers to look up"
+
+        col_index = findloc(this%headers,trim(adjustl(header)),dim=1)
+        if (col_index < 1) error stop 'header not present in data frame'
+
+        if (this%type_loc(col_index,1) /= COMPLEX_NUM) error stop 'column is not of complex type'
+        data_index = this%type_loc(col_index,2)
+
+        min_start = 1   ! 1 indexed
+        if (.not. this%enforce_length) then
+            max_end = this%col_lens(col_index)
+        else
+            max_end = this%nrows_max
+        end if
+        
+        ! MAYBE JUST USE IMPLICIT ARRAY ERRORS
+        ! if (end>max_end) error stop 'end outside of column range'
+        ! if (start<min_start) error stop 'start outside of column range'
+        ! if (start>end) error stop 'start must be smaller than end'
+
+        vals = this%cdata(start:end,data_index)
+
+    end function df_get_partial_col_header_complex
+
+! ~~~~ Get multiple partial columns using headers
+
+    pure function df_get_mult_partial_col_header_real(this,headers,start,end) result(vals)
+        class(data_frame),intent(in) :: this
+        character(*),intent(in) :: headers(:)
+        integer,intent(in) :: start, end
+        real(rk),dimension(:,:),allocatable :: vals
+
+        integer,allocatable :: data_indices(:), col_indices(:)
+        integer :: i, max_end, min_start
+
+        if (.not. this%with_headers) error stop "data frame has no headers to look up"
+
+        allocate(col_indices(size(headers,dim=1)))
+        do i=1,size(headers,dim=1)
+            col_indices(i) = findloc(this%headers,trim(adjustl(headers(i))),dim=1)
+            if (col_indices(i) < 1) error stop 'header not present in data frame'
+            if (this%type_loc(col_indices(i),1) /= REAL_NUM) error stop 'column is not of real type'
+        end do
+
+        data_indices = this%type_loc(col_indices,2)
+
+        min_start = 1   ! 1 indexed
+        if (.not. this%enforce_length) then
+            max_end = maxval(this%col_lens(col_indices))
+        else
+            max_end = this%nrows_max
+        end if
+        
+        ! MAYBE JUST USE IMPLICIT ARRAY ERRORS
+        ! if (end>max_end) error stop 'end outside of column range'
+        ! if (start<min_start) error stop 'start outside of column range'
+        ! if (start>end) error stop 'start must be smaller than end'
+
+        vals = this%rdata(start:end,data_indices)
+
+    end function df_get_mult_partial_col_header_real
+
+    pure function df_get_mult_partial_col_header_integer(this,headers,start,end) result(vals)
+        class(data_frame),intent(in) :: this
+        character(*),intent(in) :: headers(:)
+        integer,intent(in) :: start, end
+        integer(ik),dimension(:,:),allocatable :: vals
+
+        integer,allocatable :: data_indices(:), col_indices(:)
+        integer :: i, max_end, min_start
+
+        if (.not. this%with_headers) error stop "data frame has no headers to look up"
+
+        allocate(col_indices(size(headers,dim=1)))
+        do i=1,size(headers,dim=1)
+            col_indices(i) = findloc(this%headers,trim(adjustl(headers(i))),dim=1)
+            if (col_indices(i) < 1) error stop 'header not present in data frame'
+            if (this%type_loc(col_indices(i),1) /= INTEGER_NUM) error stop 'column is not of integer type'
+        end do
+
+        data_indices = this%type_loc(col_indices,2)
+
+        min_start = 1   ! 1 indexed
+        if (.not. this%enforce_length) then
+            max_end = maxval(this%col_lens(col_indices))
+        else
+            max_end = this%nrows_max
+        end if
+        
+        ! MAYBE JUST USE IMPLICIT ARRAY ERRORS
+        ! if (end>max_end) error stop 'end outside of column range'
+        ! if (start<min_start) error stop 'start outside of column range'
+        ! if (start>end) error stop 'start must be smaller than end'
+
+        vals = this%idata(start:end,data_indices)
+
+    end function df_get_mult_partial_col_header_integer
+
+    pure function df_get_mult_partial_col_header_logical(this,headers,start,end) result(vals)
+        class(data_frame),intent(in) :: this
+        character(*),intent(in) :: headers(:)
+        integer,intent(in) :: start, end
+        logical,dimension(:,:),allocatable :: vals
+
+        integer,allocatable :: data_indices(:), col_indices(:)
+        integer :: i, max_end, min_start
+
+        if (.not. this%with_headers) error stop "data frame has no headers to look up"
+
+        allocate(col_indices(size(headers,dim=1)))
+        do i=1,size(headers,dim=1)
+            col_indices(i) = findloc(this%headers,trim(adjustl(headers(i))),dim=1)
+            if (col_indices(i) < 1) error stop 'header not present in data frame'
+            if (this%type_loc(col_indices(i),1) /= LOGICAL_NUM) error stop 'column is not of logical type'
+        end do
+
+        data_indices = this%type_loc(col_indices,2)
+
+        min_start = 1   ! 1 indexed
+        if (.not. this%enforce_length) then
+            max_end = maxval(this%col_lens(col_indices))
+        else
+            max_end = this%nrows_max
+        end if
+        
+        ! MAYBE JUST USE IMPLICIT ARRAY ERRORS
+        ! if (end>max_end) error stop 'end outside of column range'
+        ! if (start<min_start) error stop 'start outside of column range'
+        ! if (start>end) error stop 'start must be smaller than end'
+
+        vals = this%ldata(start:end,data_indices)
+
+    end function df_get_mult_partial_col_header_logical
+
+    pure function df_get_mult_partial_col_header_character(this,headers,start,end) result(vals)
+        class(data_frame),intent(in) :: this
+        character(*),intent(in) :: headers(:)
+        integer,intent(in) :: start, end
+        character(:),dimension(:,:),allocatable :: vals
+
+        integer,allocatable :: data_indices(:), col_indices(:)
+        integer :: i, max_end, min_start
+
+        if (.not. this%with_headers) error stop "data frame has no headers to look up"
+
+        allocate(col_indices(size(headers,dim=1)))
+        do i=1,size(headers,dim=1)
+            col_indices(i) = findloc(this%headers,trim(adjustl(headers(i))),dim=1)
+            if (col_indices(i) < 1) error stop 'header not present in data frame'
+            if (this%type_loc(col_indices(i),1) /= CHARACTER_NUM) error stop 'column is not of character type'
+        end do
+
+        data_indices = this%type_loc(col_indices,2)
+
+        min_start = 1   ! 1 indexed
+        if (.not. this%enforce_length) then
+            max_end = maxval(this%col_lens(col_indices))
+        else
+            max_end = this%nrows_max
+        end if
+        
+        ! MAYBE JUST USE IMPLICIT ARRAY ERRORS
+        ! if (end>max_end) error stop 'end outside of column range'
+        ! if (start<min_start) error stop 'start outside of column range'
+        ! if (start>end) error stop 'start must be smaller than end'
+
+        vals = this%chdata(start:end,data_indices)
+
+    end function df_get_mult_partial_col_header_character
+
+    pure function df_get_mult_partial_col_header_complex(this,headers,start,end) result(vals)
+        class(data_frame),intent(in) :: this
+        character(*),intent(in) :: headers(:)
+        integer,intent(in) :: start, end
+        complex(rk),dimension(:,:),allocatable :: vals
+
+        integer,allocatable :: data_indices(:), col_indices(:)
+        integer :: i, max_end, min_start
+
+        if (.not. this%with_headers) error stop "data frame has no headers to look up"
+
+        allocate(col_indices(size(headers,dim=1)))
+        do i=1,size(headers,dim=1)
+            col_indices(i) = findloc(this%headers,trim(adjustl(headers(i))),dim=1)
+            if (col_indices(i) < 1) error stop 'header not present in data frame'
+            if (this%type_loc(col_indices(i),1) /= COMPLEX_NUM) error stop 'column is not of complex type'
+        end do
+
+        data_indices = this%type_loc(col_indices,2)
+
+        min_start = 1   ! 1 indexed
+        if (.not. this%enforce_length) then
+            max_end = maxval(this%col_lens(col_indices))
+        else
+            max_end = this%nrows_max
+        end if
+        
+        ! MAYBE JUST USE IMPLICIT ARRAY ERRORS
+        ! if (end>max_end) error stop 'end outside of column range'
+        ! if (start<min_start) error stop 'start outside of column range'
+        ! if (start>end) error stop 'start must be smaller than end'
+
+        vals = this%cdata(start:end,data_indices)
+
+    end function df_get_mult_partial_col_header_complex
 
 
 ! ~~~~ Change single value of data frame -> two indices

--- a/src/df_fortranDF.f90
+++ b/src/df_fortranDF.f90
@@ -155,36 +155,82 @@ module df_fortranDF
                      df_get_mult_partial_col_header_logical,    &
                      df_get_mult_partial_col_header_character,  &
                      df_get_mult_partial_col_header_complex
+        procedure :: df_get_indexed_partial_col_ind_real,       &
+                     df_get_indexed_partial_col_ind_integer,    &
+                     df_get_indexed_partial_col_ind_logical,    &
+                     df_get_indexed_partial_col_ind_character,  &
+                     df_get_indexed_partial_col_ind_complex
+        procedure :: df_get_mult_indexed_partial_col_ind_real,      &
+                     df_get_mult_indexed_partial_col_ind_integer,   &
+                     df_get_mult_indexed_partial_col_ind_logical,   &
+                     df_get_mult_indexed_partial_col_ind_character, &
+                     df_get_mult_indexed_partial_col_ind_complex
+        procedure :: df_get_indexed_partial_col_header_real,        &
+                     df_get_indexed_partial_col_header_integer,     &
+                     df_get_indexed_partial_col_header_logical,     &
+                     df_get_indexed_partial_col_header_character,   &
+                     df_get_indexed_partial_col_header_complex
+        procedure :: df_get_mult_indexed_partial_col_header_real,       &
+                     df_get_mult_indexed_partial_col_header_integer,    &
+                     df_get_mult_indexed_partial_col_header_logical,    &
+                     df_get_mult_indexed_partial_col_header_character,  &
+                     df_get_mult_indexed_partial_col_header_complex
+        
 
         generic,public :: getr => df_get_val_real, df_get_val_header_real,              &
                                   df_get_col_ind_real, df_get_col_header_real,          &
                                   df_get_mult_col_ind_real,df_get_mult_col_header_real, &
                                   df_get_partial_col_ind_real,df_get_partial_col_header_real,   &
-                                  df_get_mult_partial_col_ind_real,df_get_mult_partial_col_header_real
+                                  df_get_mult_partial_col_ind_real,                             &
+                                  df_get_mult_partial_col_header_real,                          &
+                                  df_get_indexed_partial_col_ind_real,                          &
+                                  df_get_mult_indexed_partial_col_ind_real,                     &
+                                  df_get_indexed_partial_col_header_real,                       &
+                                  df_get_mult_indexed_partial_col_header_real
 
         generic,public :: geti => df_get_val_integer, df_get_val_header_integer,        &
                                   df_get_col_ind_integer, df_get_col_header_integer,    &
                                   df_get_mult_col_ind_integer,df_get_mult_col_header_integer, &
-                                  df_get_partial_col_ind_integer,df_get_partial_col_header_integer,   &
-                                  df_get_mult_partial_col_ind_integer,df_get_mult_partial_col_header_integer
+                                  df_get_partial_col_ind_integer,df_get_partial_col_header_integer,     &
+                                  df_get_mult_partial_col_ind_integer,                                  &
+                                  df_get_mult_partial_col_header_integer,                               &
+                                  df_get_indexed_partial_col_ind_integer,                               &
+                                  df_get_mult_indexed_partial_col_ind_integer,                          &
+                                  df_get_indexed_partial_col_header_integer,                            &
+                                  df_get_mult_indexed_partial_col_header_integer
 
         generic,public :: getl => df_get_val_logical, df_get_val_header_logical,        &
                                   df_get_col_ind_logical, df_get_col_header_logical,    &
                                   df_get_mult_col_ind_logical,df_get_mult_col_header_logical, &
-                                  df_get_partial_col_ind_logical,df_get_partial_col_header_logical,   &
-                                  df_get_mult_partial_col_ind_logical,df_get_mult_partial_col_header_logical
+                                  df_get_partial_col_ind_logical,df_get_partial_col_header_logical,     &
+                                  df_get_mult_partial_col_ind_logical,                                  &
+                                  df_get_mult_partial_col_header_logical,                               &
+                                  df_get_indexed_partial_col_ind_logical,                               &
+                                  df_get_mult_indexed_partial_col_ind_logical,                          &
+                                  df_get_indexed_partial_col_header_logical,                            &
+                                  df_get_mult_indexed_partial_col_header_logical
 
         generic,public :: getch => df_get_val_character, df_get_val_header_character,       &
                                    df_get_col_ind_character, df_get_col_header_character,   &
                                    df_get_mult_col_ind_character,df_get_mult_col_header_character, &
-                                   df_get_partial_col_ind_character,df_get_partial_col_header_character,   &
-                                   df_get_mult_partial_col_ind_character,df_get_mult_partial_col_header_character
+                                   df_get_partial_col_ind_character,df_get_partial_col_header_character,    &
+                                   df_get_mult_partial_col_ind_character,                                   &
+                                   df_get_mult_partial_col_header_character,                                &
+                                   df_get_indexed_partial_col_ind_character,                                &
+                                   df_get_mult_indexed_partial_col_ind_character,                           &
+                                   df_get_indexed_partial_col_header_character,                             &
+                                   df_get_mult_indexed_partial_col_header_character
 
         generic,public :: getc => df_get_val_complex, df_get_val_header_complex,        &
                                   df_get_col_ind_complex, df_get_col_header_complex,    &
                                   df_get_mult_col_ind_complex,df_get_mult_col_header_complex, &
-                                  df_get_partial_col_ind_complex,df_get_partial_col_header_complex,   &
-                                  df_get_mult_partial_col_ind_complex,df_get_mult_partial_col_header_complex
+                                  df_get_partial_col_ind_complex,df_get_partial_col_header_complex,     &
+                                  df_get_mult_partial_col_ind_complex,                                  &
+                                  df_get_mult_partial_col_header_complex,                               &
+                                  df_get_indexed_partial_col_ind_complex,                               &
+                                  df_get_mult_indexed_partial_col_ind_complex,                          &
+                                  df_get_indexed_partial_col_header_complex,                            &
+                                  df_get_mult_indexed_partial_col_header_complex
 
         procedure :: df_change_single_indices_real,         &
                      df_change_single_indices_integer,      &
@@ -2912,6 +2958,413 @@ contains
         vals = this%cdata(start:end,data_indices)
 
     end function df_get_mult_partial_col_header_complex
+
+
+! ~~~~ Get indexed partial col using col indices
+
+    pure function df_get_indexed_partial_col_ind_real(this,col_index,row_indices) result(vals)
+        class(data_frame),intent(in) :: this
+        integer,intent(in) :: col_index, row_indices(:)
+        real(rk),dimension(:),allocatable :: vals
+
+        integer :: data_index
+
+        if (this%type_loc(col_index,1) /= REAL_NUM) error stop 'column is not of real type'
+        data_index = this%type_loc(col_index,2)
+        
+        ! Implicit array errors -> seg fault if any row_index out of range as array would
+        vals = this%rdata(row_indices,data_index)
+
+    end function df_get_indexed_partial_col_ind_real
+
+    pure function df_get_indexed_partial_col_ind_integer(this,col_index,row_indices) result(vals)
+        class(data_frame),intent(in) :: this
+        integer,intent(in) :: col_index, row_indices(:)
+        integer(ik),dimension(:),allocatable :: vals
+
+        integer :: data_index
+
+        if (this%type_loc(col_index,1) /= INTEGER_NUM) error stop 'column is not of integer type'
+        data_index = this%type_loc(col_index,2)
+        
+        ! Implicit array errors -> seg fault if any row_index out of range as array would
+        vals = this%idata(row_indices,data_index)
+
+    end function df_get_indexed_partial_col_ind_integer
+    
+    pure function df_get_indexed_partial_col_ind_logical(this,col_index,row_indices) result(vals)
+        class(data_frame),intent(in) :: this
+        integer,intent(in) :: col_index, row_indices(:)
+        logical,dimension(:),allocatable :: vals
+
+        integer :: data_index
+
+        if (this%type_loc(col_index,1) /= LOGICAL_NUM) error stop 'column is not of logical type'
+        data_index = this%type_loc(col_index,2)
+        
+        ! Implicit array errors -> seg fault if any row_index out of range as array would
+        vals = this%ldata(row_indices,data_index)
+
+    end function df_get_indexed_partial_col_ind_logical
+
+    pure function df_get_indexed_partial_col_ind_character(this,col_index,row_indices) result(vals)
+        class(data_frame),intent(in) :: this
+        integer,intent(in) :: col_index, row_indices(:)
+        character(:),dimension(:),allocatable :: vals
+
+        integer :: data_index
+
+        if (this%type_loc(col_index,1) /= CHARACTER_NUM) error stop 'column is not of character type'
+        data_index = this%type_loc(col_index,2)
+        
+        ! Implicit array errors -> seg fault if any row_index out of range as array would
+        vals = this%chdata(row_indices,data_index)
+
+    end function df_get_indexed_partial_col_ind_character
+
+    pure function df_get_indexed_partial_col_ind_complex(this,col_index,row_indices) result(vals)
+        class(data_frame),intent(in) :: this
+        integer,intent(in) :: col_index, row_indices(:)
+        complex(rk),dimension(:),allocatable :: vals
+
+        integer :: data_index
+
+        if (this%type_loc(col_index,1) /= COMPLEX_NUM) error stop 'column is not of complex type'
+        data_index = this%type_loc(col_index,2)
+        
+        ! Implicit array errors -> seg fault if any row_index out of range as array would
+        vals = this%cdata(row_indices,data_index)
+
+    end function df_get_indexed_partial_col_ind_complex
+
+
+! ~~~~ Get multiple indexed partial col using col indices
+
+    pure function df_get_mult_indexed_partial_col_ind_real(this,col_indices,row_indices) result(vals)
+        class(data_frame),intent(in) :: this
+        integer,intent(in) :: col_indices(:), row_indices(:)
+        real(rk),dimension(:,:),allocatable :: vals
+
+        integer,allocatable :: data_indices(:)
+        integer :: i
+
+        do i=1,size(col_indices,dim=1)
+            if (this%type_loc(col_indices(i),1) /= REAL_NUM) error stop 'column is not of real type'
+        end do
+        data_indices = this%type_loc(col_indices,2)
+        
+        ! Implicit array errors -> seg fault if any row_index out of range as array would
+        vals = this%rdata(row_indices,data_indices)
+
+    end function df_get_mult_indexed_partial_col_ind_real
+
+    pure function df_get_mult_indexed_partial_col_ind_integer(this,col_indices,row_indices) result(vals)
+        class(data_frame),intent(in) :: this
+        integer,intent(in) :: col_indices(:), row_indices(:)
+        integer(ik),dimension(:,:),allocatable :: vals
+
+        integer,allocatable :: data_indices(:)
+        integer :: i
+
+        do i=1,size(col_indices,dim=1)
+            if (this%type_loc(col_indices(i),1) /= INTEGER_NUM) error stop 'column is not of integer type'
+        end do
+        data_indices = this%type_loc(col_indices,2)
+        
+        ! Implicit array errors -> seg fault if any row_index out of range as array would
+        vals = this%idata(row_indices,data_indices)
+
+    end function df_get_mult_indexed_partial_col_ind_integer
+
+    pure function df_get_mult_indexed_partial_col_ind_logical(this,col_indices,row_indices) result(vals)
+        class(data_frame),intent(in) :: this
+        integer,intent(in) :: col_indices(:), row_indices(:)
+        logical,dimension(:,:),allocatable :: vals
+
+        integer,allocatable :: data_indices(:)
+        integer :: i
+
+        do i=1,size(col_indices,dim=1)
+            if (this%type_loc(col_indices(i),1) /= LOGICAL_NUM) error stop 'column is not of logical type'
+        end do
+        data_indices = this%type_loc(col_indices,2)
+        
+        ! Implicit array errors -> seg fault if any row_index out of range as array would
+        vals = this%ldata(row_indices,data_indices)
+
+    end function df_get_mult_indexed_partial_col_ind_logical
+
+    pure function df_get_mult_indexed_partial_col_ind_character(this,col_indices,row_indices) result(vals)
+        class(data_frame),intent(in) :: this
+        integer,intent(in) :: col_indices(:), row_indices(:)
+        character(:),dimension(:,:),allocatable :: vals
+
+        integer,allocatable :: data_indices(:)
+        integer :: i
+
+        do i=1,size(col_indices,dim=1)
+            if (this%type_loc(col_indices(i),1) /= CHARACTER_NUM) error stop 'column is not of character type'
+        end do
+        data_indices = this%type_loc(col_indices,2)
+        
+        ! Implicit array errors -> seg fault if any row_index out of range as array would
+        vals = this%chdata(row_indices,data_indices)
+
+    end function df_get_mult_indexed_partial_col_ind_character
+
+    pure function df_get_mult_indexed_partial_col_ind_complex(this,col_indices,row_indices) result(vals)
+        class(data_frame),intent(in) :: this
+        integer,intent(in) :: col_indices(:), row_indices(:)
+        complex(rk),dimension(:,:),allocatable :: vals
+
+        integer,allocatable :: data_indices(:)
+        integer :: i
+
+        do i=1,size(col_indices,dim=1)
+            if (this%type_loc(col_indices(i),1) /= COMPLEX_NUM) error stop 'column is not of complex type'
+        end do
+        data_indices = this%type_loc(col_indices,2)
+        
+        ! Implicit array errors -> seg fault if any row_index out of range as array would
+        vals = this%cdata(row_indices,data_indices)
+
+    end function df_get_mult_indexed_partial_col_ind_complex
+
+
+! ~~~~ Get indexed partial col using col header
+
+    pure function df_get_indexed_partial_col_header_real(this,header,row_indices) result(vals)
+        class(data_frame),intent(in) :: this
+        character(*),intent(in) :: header
+        integer,intent(in) :: row_indices(:)
+        real(rk),dimension(:),allocatable :: vals
+
+        integer :: data_index, col_index
+
+        if (.not. this%with_headers) error stop "data frame has no headers to look up"
+
+        col_index = findloc(this%headers,trim(adjustl(header)),dim=1)
+        if (col_index < 1) error stop 'header not present in data frame'
+
+        if (this%type_loc(col_index,1) /= REAL_NUM) error stop 'column is not of real type'
+        data_index = this%type_loc(col_index,2)
+        
+        ! Implicit array errors -> seg fault if any row_index out of range as array would
+        vals = this%rdata(row_indices,data_index)
+
+    end function df_get_indexed_partial_col_header_real
+
+    pure function df_get_indexed_partial_col_header_integer(this,header,row_indices) result(vals)
+        class(data_frame),intent(in) :: this
+        character(*),intent(in) :: header
+        integer,intent(in) :: row_indices(:)
+        integer(ik),dimension(:),allocatable :: vals
+
+        integer :: data_index, col_index
+
+        if (.not. this%with_headers) error stop "data frame has no headers to look up"
+
+        col_index = findloc(this%headers,trim(adjustl(header)),dim=1)
+        if (col_index < 1) error stop 'header not present in data frame'
+
+        if (this%type_loc(col_index,1) /= INTEGER_NUM) error stop 'column is not of integer type'
+        data_index = this%type_loc(col_index,2)
+        
+        ! Implicit array errors -> seg fault if any row_index out of range as array would
+        vals = this%idata(row_indices,data_index)
+
+    end function df_get_indexed_partial_col_header_integer
+
+    pure function df_get_indexed_partial_col_header_logical(this,header,row_indices) result(vals)
+        class(data_frame),intent(in) :: this
+        character(*),intent(in) :: header
+        integer,intent(in) :: row_indices(:)
+        logical,dimension(:),allocatable :: vals
+
+        integer :: data_index, col_index
+
+        if (.not. this%with_headers) error stop "data frame has no headers to look up"
+
+        col_index = findloc(this%headers,trim(adjustl(header)),dim=1)
+        if (col_index < 1) error stop 'header not present in data frame'
+
+        if (this%type_loc(col_index,1) /= LOGICAL_NUM) error stop 'column is not of logical type'
+        data_index = this%type_loc(col_index,2)
+        
+        ! Implicit array errors -> seg fault if any row_index out of range as array would
+        vals = this%ldata(row_indices,data_index)
+
+    end function df_get_indexed_partial_col_header_logical
+
+    pure function df_get_indexed_partial_col_header_character(this,header,row_indices) result(vals)
+        class(data_frame),intent(in) :: this
+        character(*),intent(in) :: header
+        integer,intent(in) :: row_indices(:)
+        character(:),dimension(:),allocatable :: vals
+
+        integer :: data_index, col_index
+
+        if (.not. this%with_headers) error stop "data frame has no headers to look up"
+
+        col_index = findloc(this%headers,trim(adjustl(header)),dim=1)
+        if (col_index < 1) error stop 'header not present in data frame'
+
+        if (this%type_loc(col_index,1) /= CHARACTER_NUM) error stop 'column is not of character type'
+        data_index = this%type_loc(col_index,2)
+        
+        ! Implicit array errors -> seg fault if any row_index out of range as array would
+        vals = this%chdata(row_indices,data_index)
+
+    end function df_get_indexed_partial_col_header_character
+
+    pure function df_get_indexed_partial_col_header_complex(this,header,row_indices) result(vals)
+        class(data_frame),intent(in) :: this
+        character(*),intent(in) :: header
+        integer,intent(in) :: row_indices(:)
+        complex(rk),dimension(:),allocatable :: vals
+
+        integer :: data_index, col_index
+
+        if (.not. this%with_headers) error stop "data frame has no headers to look up"
+
+        col_index = findloc(this%headers,trim(adjustl(header)),dim=1)
+        if (col_index < 1) error stop 'header not present in data frame'
+
+        if (this%type_loc(col_index,1) /= COMPLEX_NUM) error stop 'column is not of complex type'
+        data_index = this%type_loc(col_index,2)
+        
+        ! Implicit array errors -> seg fault if any row_index out of range as array would
+        vals = this%cdata(row_indices,data_index)
+
+    end function df_get_indexed_partial_col_header_complex
+
+
+! ~~~~ Get multiple indexed partial cols using col headers
+
+    pure function df_get_mult_indexed_partial_col_header_real(this,headers,row_indices) result(vals)
+        class(data_frame),intent(in) :: this
+        character(*),intent(in) :: headers(:)
+        integer,intent(in) :: row_indices(:)
+        real(rk),dimension(:,:),allocatable :: vals
+
+        integer,allocatable :: data_indices(:), col_indices(:)
+        integer :: i
+
+        if (.not. this%with_headers) error stop "data frame has no headers to look up"
+
+        allocate(col_indices(size(headers,dim=1)))
+        do i=1,size(headers,dim=1)
+            col_indices(i) = findloc(this%headers,trim(adjustl(headers(i))),dim=1)
+            if (col_indices(i) < 1) error stop 'header not present in data frame'
+            if (this%type_loc(col_indices(i),1) /= REAL_NUM) error stop 'column is not of real type'
+        end do
+
+        data_indices = this%type_loc(col_indices,2)
+        
+        ! Implicit array errors -> seg fault if any row_index out of range as array would
+        vals = this%rdata(row_indices,data_indices)
+
+    end function df_get_mult_indexed_partial_col_header_real
+
+    pure function df_get_mult_indexed_partial_col_header_integer(this,headers,row_indices) result(vals)
+        class(data_frame),intent(in) :: this
+        character(*),intent(in) :: headers(:)
+        integer,intent(in) :: row_indices(:)
+        integer(ik),dimension(:,:),allocatable :: vals
+
+        integer,allocatable :: data_indices(:), col_indices(:)
+        integer :: i
+
+        if (.not. this%with_headers) error stop "data frame has no headers to look up"
+
+        allocate(col_indices(size(headers,dim=1)))
+        do i=1,size(headers,dim=1)
+            col_indices(i) = findloc(this%headers,trim(adjustl(headers(i))),dim=1)
+            if (col_indices(i) < 1) error stop 'header not present in data frame'
+            if (this%type_loc(col_indices(i),1) /= INTEGER_NUM) error stop 'column is not of integer type'
+        end do
+
+        data_indices = this%type_loc(col_indices,2)
+        
+        ! Implicit array errors -> seg fault if any row_index out of range as array would
+        vals = this%idata(row_indices,data_indices)
+
+    end function df_get_mult_indexed_partial_col_header_integer
+
+    pure function df_get_mult_indexed_partial_col_header_logical(this,headers,row_indices) result(vals)
+        class(data_frame),intent(in) :: this
+        character(*),intent(in) :: headers(:)
+        integer,intent(in) :: row_indices(:)
+        logical,dimension(:,:),allocatable :: vals
+
+        integer,allocatable :: data_indices(:), col_indices(:)
+        integer :: i
+
+        if (.not. this%with_headers) error stop "data frame has no headers to look up"
+
+        allocate(col_indices(size(headers,dim=1)))
+        do i=1,size(headers,dim=1)
+            col_indices(i) = findloc(this%headers,trim(adjustl(headers(i))),dim=1)
+            if (col_indices(i) < 1) error stop 'header not present in data frame'
+            if (this%type_loc(col_indices(i),1) /= LOGICAL_NUM) error stop 'column is not of logical type'
+        end do
+
+        data_indices = this%type_loc(col_indices,2)
+        
+        ! Implicit array errors -> seg fault if any row_index out of range as array would
+        vals = this%ldata(row_indices,data_indices)
+
+    end function df_get_mult_indexed_partial_col_header_logical
+
+    pure function df_get_mult_indexed_partial_col_header_character(this,headers,row_indices) result(vals)
+        class(data_frame),intent(in) :: this
+        character(*),intent(in) :: headers(:)
+        integer,intent(in) :: row_indices(:)
+        character(:),dimension(:,:),allocatable :: vals
+
+        integer,allocatable :: data_indices(:), col_indices(:)
+        integer :: i
+
+        if (.not. this%with_headers) error stop "data frame has no headers to look up"
+
+        allocate(col_indices(size(headers,dim=1)))
+        do i=1,size(headers,dim=1)
+            col_indices(i) = findloc(this%headers,trim(adjustl(headers(i))),dim=1)
+            if (col_indices(i) < 1) error stop 'header not present in data frame'
+            if (this%type_loc(col_indices(i),1) /= CHARACTER_NUM) error stop 'column is not of character type'
+        end do
+
+        data_indices = this%type_loc(col_indices,2)
+        
+        ! Implicit array errors -> seg fault if any row_index out of range as array would
+        vals = this%chdata(row_indices,data_indices)
+
+    end function df_get_mult_indexed_partial_col_header_character
+
+    pure function df_get_mult_indexed_partial_col_header_complex(this,headers,row_indices) result(vals)
+        class(data_frame),intent(in) :: this
+        character(*),intent(in) :: headers(:)
+        integer,intent(in) :: row_indices(:)
+        complex(rk),dimension(:,:),allocatable :: vals
+
+        integer,allocatable :: data_indices(:), col_indices(:)
+        integer :: i
+
+        if (.not. this%with_headers) error stop "data frame has no headers to look up"
+
+        allocate(col_indices(size(headers,dim=1)))
+        do i=1,size(headers,dim=1)
+            col_indices(i) = findloc(this%headers,trim(adjustl(headers(i))),dim=1)
+            if (col_indices(i) < 1) error stop 'header not present in data frame'
+            if (this%type_loc(col_indices(i),1) /= COMPLEX_NUM) error stop 'column is not of complex type'
+        end do
+
+        data_indices = this%type_loc(col_indices,2)
+        
+        ! Implicit array errors -> seg fault if any row_index out of range as array would
+        vals = this%cdata(row_indices,data_indices)
+
+    end function df_get_mult_indexed_partial_col_header_complex
 
 
 ! ~~~~ Change single value of data frame -> two indices

--- a/src/df_fortranDF.f90
+++ b/src/df_fortranDF.f90
@@ -119,6 +119,11 @@ module df_fortranDF
                      df_get_col_ind_logical,    &
                      df_get_col_ind_character,  &
                      df_get_col_ind_complex
+        procedure :: df_get_mult_col_ind_real,      &
+                     df_get_mult_col_ind_integer,   &
+                     df_get_mult_col_ind_logical,   &
+                     df_get_mult_col_ind_character, &
+                     df_get_mult_col_ind_complex
         procedure :: df_get_col_header_real,        &
                      df_get_col_header_integer,     &
                      df_get_col_header_logical,     &
@@ -126,15 +131,20 @@ module df_fortranDF
                      df_get_col_header_complex
 
         generic,public :: getr => df_get_val_real, df_get_val_header_real,              &
-                                  df_get_col_ind_real, df_get_col_header_real
+                                  df_get_col_ind_real, df_get_col_header_real,          &
+                                  df_get_mult_col_ind_real
         generic,public :: geti => df_get_val_integer, df_get_val_header_integer,        &
-                                  df_get_col_ind_integer, df_get_col_header_integer
+                                  df_get_col_ind_integer, df_get_col_header_integer,    &
+                                  df_get_mult_col_ind_integer
         generic,public :: getl => df_get_val_logical, df_get_val_header_logical,        &
-                                  df_get_col_ind_logical, df_get_col_header_logical
-        generic,public :: getch => df_get_val_character, df_get_val_header_character,   &
-                                   df_get_col_ind_character, df_get_col_header_character
+                                  df_get_col_ind_logical, df_get_col_header_logical,    &
+                                  df_get_mult_col_ind_logical
+        generic,public :: getch => df_get_val_character, df_get_val_header_character,       &
+                                   df_get_col_ind_character, df_get_col_header_character,   &
+                                   df_get_mult_col_ind_character
         generic,public :: getc => df_get_val_complex, df_get_val_header_complex,        &
-                                  df_get_col_ind_complex, df_get_col_header_complex
+                                  df_get_col_ind_complex, df_get_col_header_complex,    &
+                                  df_get_mult_col_ind_complex
 
         procedure :: df_change_single_indices_real,         &
                      df_change_single_indices_integer,      &
@@ -1559,6 +1569,150 @@ contains
     end function df_get_col_ind_complex
 
 
+! ~~~~ Get multiple columns from indices
+
+    pure function df_get_mult_col_ind_real(this,col_indices,full) result(cols)
+        class(data_frame),intent(in) :: this
+        integer,intent(in) :: col_indices(:)
+        logical,intent(in),optional :: full ! return full column
+        real(rk),dimension(:,:),allocatable :: cols
+
+        integer,allocatable :: indices(:)
+        integer :: i, max_len
+
+        do i=1,size(col_indices,dim=1)
+            if (this%type_loc(col_indices(i),1) /= REAL_NUM) error stop 'column is not of real type'
+        end do
+        indices = this%type_loc(col_indices,2)
+
+        if (.not. this%enforce_length) then
+            max_len = maxval(this%col_lens(col_indices))
+        else
+            max_len = this%nrows_max
+        end if
+        
+        if (present(full)) then
+            if (full) max_len = this%rrows_max
+        end if
+
+        cols = this%rdata(:max_len,indices)
+
+    end function df_get_mult_col_ind_real
+
+    pure function df_get_mult_col_ind_integer(this,col_indices,full) result(cols)
+        class(data_frame),intent(in) :: this
+        integer,intent(in) :: col_indices(:)
+        logical,intent(in),optional :: full ! return full column
+        integer(ik),dimension(:,:),allocatable :: cols
+
+        integer,allocatable :: indices(:)
+        integer :: i, max_len
+
+        do i=1,size(col_indices,dim=1)
+            if (this%type_loc(col_indices(i),1) /= INTEGER_NUM) error stop 'column is not of integer type'
+        end do
+        indices = this%type_loc(col_indices,2)
+
+        if (.not. this%enforce_length) then
+            max_len = maxval(this%col_lens(col_indices))
+        else
+            max_len = this%nrows_max
+        end if
+        
+        if (present(full)) then
+            if (full) max_len = this%irows_max
+        end if
+
+        cols = this%idata(:max_len,indices)
+
+    end function df_get_mult_col_ind_integer
+
+    pure function df_get_mult_col_ind_logical(this,col_indices,full) result(cols)
+        class(data_frame),intent(in) :: this
+        integer,intent(in) :: col_indices(:)
+        logical,intent(in),optional :: full ! return full column
+        logical,dimension(:,:),allocatable :: cols
+
+        integer,allocatable :: indices(:)
+        integer :: i, max_len
+
+        do i=1,size(col_indices,dim=1)
+            if (this%type_loc(col_indices(i),1) /= LOGICAL_NUM) error stop 'column is not of logical type'
+        end do
+        indices = this%type_loc(col_indices,2)
+
+        if (.not. this%enforce_length) then
+            max_len = maxval(this%col_lens(col_indices))
+        else
+            max_len = this%nrows_max
+        end if
+        
+        if (present(full)) then
+            if (full) max_len = this%lrows_max
+        end if
+
+        cols = this%ldata(:max_len,indices)
+
+    end function df_get_mult_col_ind_logical
+
+    pure function df_get_mult_col_ind_character(this,col_indices,full) result(cols)
+        class(data_frame),intent(in) :: this
+        integer,intent(in) :: col_indices(:)
+        logical,intent(in),optional :: full ! return full column
+        character(:),dimension(:,:),allocatable :: cols
+
+        integer,allocatable :: indices(:)
+        integer :: i, max_len
+
+        do i=1,size(col_indices,dim=1)
+            if (this%type_loc(col_indices(i),1) /= CHARACTER_NUM) error stop 'column is not of character type'
+        end do
+        indices = this%type_loc(col_indices,2)
+
+        if (.not. this%enforce_length) then
+            max_len = maxval(this%col_lens(col_indices))
+        else
+            max_len = this%nrows_max
+        end if
+        
+        if (present(full)) then
+            if (full) max_len = this%chrows_max
+        end if
+
+        cols = this%chdata(:max_len,indices)
+
+    end function df_get_mult_col_ind_character
+
+    pure function df_get_mult_col_ind_complex(this,col_indices,full) result(cols)
+        class(data_frame),intent(in) :: this
+        integer,intent(in) :: col_indices(:)
+        logical,intent(in),optional :: full ! return full column
+        complex(rk),dimension(:,:),allocatable :: cols
+
+        integer,allocatable :: indices(:)
+        integer :: i, max_len
+
+        do i=1,size(col_indices,dim=1)
+            if (this%type_loc(col_indices(i),1) /= COMPLEX_NUM) error stop 'column is not of complex type'
+        end do
+        indices = this%type_loc(col_indices,2)
+
+        if (.not. this%enforce_length) then
+            max_len = maxval(this%col_lens(col_indices))
+        else
+            max_len = this%nrows_max
+        end if
+        
+        if (present(full)) then
+            if (full) max_len = this%crows_max
+        end if
+
+        cols = this%cdata(:max_len,indices)
+
+    end function df_get_mult_col_ind_complex
+
+
+    
 ! ~~~~ Get Column DF from header
 
     pure function df_get_col_header_real(this,header,full) result(col)


### PR DESCRIPTION
Adding many new getter functions that help simplify retrieving several columns of data at once. All functions have been added to the generic `df%get*()` interfaces.

Main functionality for new procedures:

-get multiple full columns
`call df%getr(["col1","col2"])` returns a real array consisting of data stored in columns named "col1" and "col2"
`call df%geti([1,2,3,2])` returns an integer array consisting of the data stored in 1st, 2nd, 3rd, and 2nd columns (in that order)

-get range of values from a single or multiple columns
`call df%getl("col1",1,5)` returns rows 1 through 5 of logical columns"col1"

-get indexed set of values from a single or multiple columns 
`call df%getch("names",[1,2,3,7,1])` returns rank 1 character array of 1st, 2nd, 3rd, 7th, and 1st elements of "names" 

All new functions support using column indices or headers to select columns.

Partially addresses https://github.com/jaiken17/fortranDF/issues/10